### PR TITLE
Remove "Your Clips" section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Sidebar Menu Cleanup**: Removed "Your clips" menu item from the sidebar
+  - Removed disabled "Your clips" item from the Library section
+  - Removed unused Scissors icon import from lucide-react
+  - Streamlines the navigation menu by removing non-functional placeholder items
+
 - **Play/Pause Overlay Component**: Refactored animated play/pause overlay into reusable component
   - Created new `PlayPauseOverlay` component in `src/components/PlayPauseOverlay.tsx`
   - Extracted duplicate play/pause animation logic from `VideoPlayer` and `ShortsVideoPage`

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { Home, Play, Users, History, ListVideo, ThumbsUp, Clock, Scissors, Cog } from 'lucide-react'
+import { Home, Play, Users, History, ListVideo, ThumbsUp, Clock, Cog } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { Separator } from '@/components/ui/separator'
 import { useCurrentUser, useAppContext, useReadRelays } from '@/hooks'
@@ -33,7 +33,6 @@ export function Sidebar() {
     },
     { name: 'Watch later', icon: Clock, href: '/watch-later', disabled: true },
     { name: 'Liked videos', icon: ThumbsUp, href: '/liked-videos' },
-    { name: 'Your clips', icon: Scissors, href: '/clips', disabled: true },
   ]
 
   const configItems = [{ name: 'Settings', icon: Cog, href: '/settings', disabled: false }]


### PR DESCRIPTION
- Removed disabled 'Your clips' item from the Library section
- Removed unused Scissors icon import from lucide-react
- Streamlines the navigation menu by removing non-functional placeholder items