### PR TITLE
fix: hide Subscriptions and Playlists in mobile bottom nav when not logged in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Video feeds: all timelines and feeds now sorted by `published_at` date (with `created_at` as fallback) for correct video ordering; video page shows "updated X ago" in parentheses when video was edited after publishing
 - Video cards: hover effect changed from upward shift to centered zoom for smoother visual feedback
 - Sidebar: hide Subscriptions and Playlists menu items in mini sidebar when not logged in (matches full sidebar behavior)
+- Mobile navigation: hide Subscriptions and Playlists in bottom nav when not logged in (matches sidebar behavior)
 - Playlists: playlist manager now shows video thumbnails and titles for each video in the accordion list; missing video events are automatically loaded from relays
 - Comments: improved highlight animation for parent comment navigation - smoother 1.5s fade with multi-step keyframes and CSS transitions
 - Comments: single replies are now auto-expanded (no expand button needed); expand/collapse button only shown when there are 2+ replies

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -2,10 +2,12 @@ import { Home, Play, Users, ListVideo } from 'lucide-react'
 import { Link, useLocation } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
+import { useCurrentUser } from '@/hooks'
 
 export function MobileBottomNav() {
   const { t } = useTranslation()
   const location = useLocation()
+  const { user } = useCurrentUser()
 
   const navItems = [
     {
@@ -18,16 +20,21 @@ export function MobileBottomNav() {
       icon: Play,
       href: '/shorts',
     },
-    {
-      label: t('navigation.subscriptions'),
-      icon: Users,
-      href: '/subscriptions',
-    },
-    {
-      label: t('navigation.playlists'),
-      icon: ListVideo,
-      href: '/playlists',
-    },
+    // Only show Subscriptions and Playlists when logged in
+    ...(user
+      ? [
+          {
+            label: t('navigation.subscriptions'),
+            icon: Users,
+            href: '/subscriptions',
+          },
+          {
+            label: t('navigation.playlists'),
+            icon: ListVideo,
+            href: '/playlists',
+          },
+        ]
+      : []),
   ]
 
   return (


### PR DESCRIPTION
Added login check to MobileBottomNav component using useCurrentUser hook.
Subscriptions and Playlists menu items are now conditionally rendered only
when a user is logged in, matching the existing behavior in MiniSidebar.

https://claude.ai/code/session_01U9kkpmcrcQTyBjWReeNm8b