### PR TITLE
fix: harden browser storage security for secrets and keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Bunker URIs no longer persist the `secret` query parameter to localStorage — the secret is only needed during the initial NIP-46 handshake; the client key alone restores sessions
+- Stripped `secret` from `nostube:last-bunker` localStorage entry and from QR-code login persistence
+- Auth token fragment logging in `blossom-upload.ts` now gated behind `import.meta.env.DEV` — previously leaked first 50 chars of Nostr auth tokens to the console in production
+- nsec input field now uses `type="password"` to prevent shoulder surfing
+- Added `autocomplete="off"` to nsec and bunker URI inputs to prevent browser credential caching
+- nsec is now cleared from React state in SignupDialog after successful login (was already done in LoginDialog)
+
 ### Fixed
 
 - Follow import dialog flashing briefly on page load — now waits for the kind 10020 follow set query to complete (EOSE) before deciding whether to show the import prompt

--- a/package-lock.json
+++ b/package-lock.json
@@ -227,7 +227,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1838,7 +1837,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1879,7 +1877,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1907,7 +1904,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -5629,7 +5625,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5805,7 +5802,6 @@
       "integrity": "sha512-zWW5KPngR/yvakJgGOmZ5vTBemDoSqF3AcV/LrO5u5wTWyEAVVh+IT39G4gtyAkh3CtTZs8aX/yRM82OfzHJRg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5816,7 +5812,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5827,7 +5822,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5903,7 +5897,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -6289,7 +6282,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7603,7 +7595,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8365,7 +8356,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8408,8 +8400,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -8695,7 +8686,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9568,7 +9558,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -9642,7 +9631,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -10359,7 +10347,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -10869,6 +10856,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -12089,7 +12077,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -12183,6 +12170,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -12198,6 +12186,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12210,7 +12199,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -12263,7 +12253,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12294,7 +12283,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -12324,7 +12312,6 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.71.1.tgz",
       "integrity": "sha512-9SUJKCGKo8HUSsCO+y0CtqkqI5nNuaDqTxyqPsZPqIwudpj4rCrAz/jZV+jn57bx5gtZKOh3neQu94DXMc+w5w==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -12390,7 +12377,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -12593,8 +12579,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -12816,7 +12801,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.0.tgz",
       "integrity": "sha512-e5lPJi/aui4TO1LpAXIRLySmwXSE8k3b9zoGfd42p67wzxog4WHjiZF3M2uheQih4DGyc25QEV4yRBbpueNiUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12892,7 +12876,6 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -13494,8 +13477,7 @@
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -13815,7 +13797,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -14193,7 +14174,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -14741,7 +14721,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14809,7 +14788,6 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -15127,7 +15105,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/auth/LoginDialog.tsx
+++ b/src/components/auth/LoginDialog.tsx
@@ -112,7 +112,15 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin, onS
 
     try {
       await login.bunker(bunkerUri, { onAuth: handleBunkerAuth })
-      localStorage.setItem('nostube:last-bunker', bunkerUri.trim())
+      // Store bunker URI without secret param (secret is only for initial handshake)
+      try {
+        const uri = new URL(bunkerUri.trim())
+        uri.searchParams.delete('secret')
+        localStorage.setItem('nostube:last-bunker', uri.toString())
+      } catch {
+        // If not a valid URL (e.g. NIP-05 input), store as-is
+        localStorage.setItem('nostube:last-bunker', bunkerUri.trim())
+      }
       setAuthUrl(null)
       onLogin()
       onClose()
@@ -214,6 +222,8 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin, onS
                   </label>
                   <Input
                     id="nsec"
+                    type="password"
+                    autoComplete="off"
                     value={nsec}
                     onChange={e => setNsec(e.target.value)}
                     className="rounded-lg focus-visible:ring-primary"
@@ -260,6 +270,7 @@ const LoginDialog: React.FC<LoginDialogProps> = ({ isOpen, onClose, onLogin, onS
                 </label>
                 <Input
                   id="bunkerUri"
+                  autoComplete="off"
                   value={bunkerUri}
                   onChange={e => setBunkerUri(e.target.value)}
                   className="rounded-lg border-gray-300 dark:border-gray-700 focus-visible:ring-primary"

--- a/src/components/auth/QRCodeLogin.tsx
+++ b/src/components/auth/QRCodeLogin.tsx
@@ -13,13 +13,12 @@ import { useTranslation } from 'react-i18next'
 // Relays used for nostrconnect communication
 const NOSTRCONNECT_RELAYS = presetRelays.map(r => r.url)
 
-// Build a bunker:// URI from signer properties for persistence
-function buildBunkerUri(remotePubkey: string, relays: string[], secret?: string): string {
+// Build a bunker:// URI from signer properties for persistence.
+// The secret is intentionally omitted — it is only needed for the initial
+// NIP-46 handshake and should never be persisted to storage.
+function buildBunkerUri(remotePubkey: string, relays: string[]): string {
   const params = new URLSearchParams()
   relays.forEach(relay => params.append('relay', relay))
-  if (secret) {
-    params.append('secret', secret)
-  }
   return `bunker://${remotePubkey}?${params.toString()}`
 }
 
@@ -86,7 +85,7 @@ export function QRCodeLogin({ onLogin, onError }: QRCodeLoginProps) {
       if (!remotePubkey) {
         throw new Error('Failed to get remote signer pubkey')
       }
-      const bunkerUri = buildBunkerUri(remotePubkey, NOSTRCONNECT_RELAYS, signer.secret)
+      const bunkerUri = buildBunkerUri(remotePubkey, NOSTRCONNECT_RELAYS)
 
       // Persist account
       saveAccountToStorage(account, 'bunker', bunkerUri)

--- a/src/components/auth/SignupDialog.tsx
+++ b/src/components/auth/SignupDialog.tsx
@@ -76,6 +76,7 @@ const SignupDialog: React.FC<SignupDialogProps> = ({ isOpen, onClose }) => {
     setIsLoading(true)
     try {
       await login.nsec(nsec)
+      setNsec('') // Clear nsec from memory after successful login
       setStep('done')
       onClose()
 

--- a/src/hooks/useAccountPersistence.ts
+++ b/src/hooks/useAccountPersistence.ts
@@ -9,6 +9,22 @@ const STORAGE_KEY_ACTIVE = 'nostr:active-account'
 
 export type AccountMethod = 'extension' | 'nsec' | 'bunker'
 
+/**
+ * Strip the `secret` query parameter from a bunker:// URI before persisting.
+ * The secret is only needed during the initial NIP-46 handshake and should not
+ * be stored long-term — the clientKey alone is sufficient to restore a session.
+ */
+function stripBunkerSecret(bunkerUri: string): string {
+  try {
+    const url = new URL(bunkerUri)
+    url.searchParams.delete('secret')
+    return url.toString()
+  } catch {
+    // If parsing fails, return the original (will be validated elsewhere)
+    return bunkerUri
+  }
+}
+
 export interface PersistedAccount {
   pubkey: string
   method: AccountMethod
@@ -35,7 +51,13 @@ export function saveAccountToStorage(
     const accountData: PersistedAccount = {
       pubkey: account.pubkey,
       method,
-      data: method === 'nsec' ? undefined : data, // Don't store nsec for security
+      // Don't store nsec for security; strip secret from bunker URIs (only needed for initial handshake)
+      data:
+        method === 'nsec'
+          ? undefined
+          : method === 'bunker' && data
+            ? stripBunkerSecret(data)
+            : data,
       createdAt: existingIndex >= 0 ? accounts[existingIndex].createdAt : Date.now(),
     }
 

--- a/src/lib/blossom-upload.ts
+++ b/src/lib/blossom-upload.ts
@@ -20,15 +20,15 @@ async function customMirrorBlob(
   // Normalize server URL to prevent double slashes
   const normalizedServer = normalizeServerUrl(server)
 
-  console.log(`[MIRROR] Mirroring blob to ${normalizedServer}`)
-  console.log(
-    `[MIRROR] Auth token received:`,
-    authToken ? 'YES' : 'NO',
-    'Length:',
-    authToken?.length || 0,
-    'First 50:',
-    authToken?.substring(0, 50) || 'EMPTY'
-  )
+  if (import.meta.env.DEV) {
+    console.log(`[MIRROR] Mirroring blob to ${normalizedServer}`)
+    console.log(
+      `[MIRROR] Auth token received:`,
+      authToken ? 'YES' : 'NO',
+      'Length:',
+      authToken?.length || 0
+    )
+  }
 
   const response = await fetch(`${normalizedServer}/mirror`, {
     method: 'PUT',
@@ -62,11 +62,13 @@ export async function mirrorBlobsToServers({
   if (import.meta.env.DEV) console.log('Mirroring blobs to servers', mirrorServers, blob)
 
   // Create per-server auth tokens with server tags for BUD-11 scoping
-  console.log(`[MIRROR] Creating auth tokens for ${mirrorServers.length} servers`)
+  if (import.meta.env.DEV)
+    console.log(`[MIRROR] Creating auth tokens for ${mirrorServers.length} servers`)
 
   const results = await Promise.allSettled(
     mirrorServers.map(async (server, index) => {
-      console.log(`[MIRROR ${index + 1}/${mirrorServers.length}] Processing server: ${server}`)
+      if (import.meta.env.DEV)
+        console.log(`[MIRROR ${index + 1}/${mirrorServers.length}] Processing server: ${server}`)
 
       // Check if file already exists on this server
       const fileExists = await checkFileExists(server, blob.sha256)


### PR DESCRIPTION
- Strip `secret` param from bunker URIs before persisting to localStorage
  (secret is only needed for initial NIP-46 handshake, not session restore)
- Remove secret from QRCodeLogin bunker URI builder and last-bunker storage
- Gate auth token fragment logging behind import.meta.env.DEV in blossom-upload
- Add type="password" and autocomplete="off" to nsec and bunker inputs
- Clear nsec from SignupDialog state after successful login

https://claude.ai/code/session_01MXLXgPiUH4xb47NDpeDsCo