### PR TITLE
refactor: deepen the playback URL ladder into one module per Video Event

### DIFF
--- a/src/components/player/VideoElement.tsx
+++ b/src/components/player/VideoElement.tsx
@@ -44,22 +44,23 @@ export const VideoElement = forwardRef<HTMLVideoElement, VideoElementProps>(func
  * Caption Track component with automatic failover using useMediaUrls
  */
 function CaptionTrack({ track, sha256 }: { track: TextTrack; sha256?: string }) {
-  const { currentUrl, moveToNext, hasMore } = useMediaUrls({
+  const { ladder } = useMediaUrls({
     urls: [track.url],
     mediaType: 'vtt',
     sha256,
   })
+  const currentUrl = ladder.currentUrl
 
   const handleTrackError = useCallback(() => {
-    if (hasMore) {
+    if (ladder.hasMore) {
       if (import.meta.env.DEV) {
         console.log(`VTT track error for ${track.lang}, trying next URL...`)
       }
-      moveToNext()
+      ladder.tryNext()
     } else {
       console.warn(`All VTT track URLs failed for ${track.lang}`)
     }
-  }, [hasMore, moveToNext, track.lang])
+  }, [ladder, track.lang])
 
   if (!currentUrl) {
     return null

--- a/src/components/player/VideoPlayer.test.tsx
+++ b/src/components/player/VideoPlayer.test.tsx
@@ -8,15 +8,13 @@ vi.mock('@/hooks', () => ({
 
 vi.mock('@/hooks/useMediaUrls', () => ({
   useMediaUrls: ({ urls }: { urls: string[] }) => ({
-    urls,
+    ladder: {
+      currentUrl: urls[0] ?? null,
+      hasMore: false,
+      tryNext: vi.fn(),
+    },
     isLoading: false,
-    isDiscovering: false,
     error: null,
-    currentIndex: 0,
-    currentUrl: urls[0] ?? null,
-    moveToNext: vi.fn(),
-    reset: vi.fn(),
-    hasMore: false,
   }),
 }))
 

--- a/src/components/player/VideoPlayer.tsx
+++ b/src/components/player/VideoPlayer.tsx
@@ -172,11 +172,6 @@ export const VideoPlayer = React.memo(function VideoPlayer({
     urlsRef.current = urls
   }, [onAllSourcesFailed, urls])
 
-  // Video URL failover
-  const handleVideoUrlError = useCallback((error: Error) => {
-    console.error('Video URL failover error:', error)
-  }, [])
-
   const hasHlsSource = useMemo(
     () =>
       baseMime === 'application/vnd.apple.mpegurl' ||
@@ -194,21 +189,18 @@ export const VideoPlayer = React.memo(function VideoPlayer({
   const hasManifestSource = hasHlsSource || hasDashSource
   const proxyConfig = useMemo(() => ({ enabled: !hasManifestSource }), [hasManifestSource])
 
-  const {
-    currentUrl: videoUrl,
-    ladder: videoUrlLadder,
-    moveToNext: moveToNextVideo,
-    hasMore: hasMoreVideoUrls,
-    isLoading: isLoadingVideoUrls,
-  } = useMediaUrls({
+  const { ladder: videoUrlLadder, isLoading: isLoadingVideoUrls } = useMediaUrls({
     urls: effectiveUrls,
+    variants: videoVariants,
     mediaType: isAudioOnly ? 'audio' : 'video',
     sha256: effectiveSha256,
     kind: 34235,
     authorPubkey,
     proxyConfig,
-    onError: handleVideoUrlError,
   })
+  const videoUrl = videoUrlLadder.currentUrl
+  const hasMoreVideoUrls = videoUrlLadder.hasMore
+  const moveToNextVideo = videoUrlLadder.tryNext.bind(videoUrlLadder)
 
   useEffect(() => {
     if (!import.meta.env.DEV) return
@@ -979,12 +971,13 @@ export const VideoPlayer = React.memo(function VideoPlayer({
 
   // Get poster URL with blossom fallback support (no resize proxy)
   const posterUrls = useMemo(() => (poster ? [poster] : []), [poster])
-  const { currentUrl: posterUrl } = useMediaUrls({
+  const { ladder: posterUrlLadder } = useMediaUrls({
     urls: posterUrls,
     mediaType: 'image',
     sha256: posterHash,
     enabled: !!poster,
   })
+  const posterUrl = posterUrlLadder.currentUrl
 
   // Media Session API - lock screen / Control Center controls + background audio
   useMediaSession({

--- a/src/components/player/VideoPlayer.tsx
+++ b/src/components/player/VideoPlayer.tsx
@@ -196,6 +196,7 @@ export const VideoPlayer = React.memo(function VideoPlayer({
 
   const {
     currentUrl: videoUrl,
+    ladder: videoUrlLadder,
     moveToNext: moveToNextVideo,
     hasMore: hasMoreVideoUrls,
     isLoading: isLoadingVideoUrls,
@@ -266,6 +267,7 @@ export const VideoPlayer = React.memo(function VideoPlayer({
   const engine = usePlaybackEngine({
     videoRef,
     videoUrl,
+    ladder: videoUrlLadder,
     mime,
     effectiveUrls,
     videoVariants,

--- a/src/components/player/engines/usePlaybackEngine.test.ts
+++ b/src/components/player/engines/usePlaybackEngine.test.ts
@@ -2,6 +2,7 @@ import { createRef } from 'react'
 import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { VideoVariant } from '@/utils/video-event'
+import { PlaybackUrlLadder } from '@/lib/playback-url-ladder'
 import {
   usePlaybackEngine,
   resolvePlaybackMode,
@@ -139,6 +140,12 @@ describe('usePlaybackEngine adapters', () => {
       isLoading: false,
       error: null,
     })
+    const ladder = new PlaybackUrlLadder({
+      urls: ['https://cdn/x.m3u8'],
+      blossomServers: [],
+      mediaType: 'video',
+    })
+
 
     const { result } = renderHook(() =>
       usePlaybackEngine({
@@ -146,6 +153,7 @@ describe('usePlaybackEngine adapters', () => {
         videoUrl: 'https://cdn/x.m3u8',
         mime: 'application/vnd.apple.mpegurl',
         effectiveUrls: ['https://cdn/x.m3u8'],
+        ladder,
       })
     )
 
@@ -159,6 +167,15 @@ describe('usePlaybackEngine adapters', () => {
     ])
     expect(result.current.selectedQuality).toBe(-1)
     expect(result.current.activeQualityLabel).toBe('720p')
+    expect(useHls).toHaveBeenLastCalledWith(
+      videoRef,
+      'https://cdn/x.m3u8',
+      true,
+      ladder,
+      undefined,
+      undefined,
+      'never'
+    )
   })
 
   it('dash adapter manages the source and exposes no selectable quality', () => {

--- a/src/components/player/engines/usePlaybackEngine.ts
+++ b/src/components/player/engines/usePlaybackEngine.ts
@@ -1,5 +1,6 @@
 import { useMemo, type RefObject } from 'react'
 import type { VideoVariant } from '@/utils/video-event'
+import type { PlaybackUrlLadder } from '@/lib/playback-url-ladder'
 import { useHls } from '../hooks/useHls'
 import { useDash } from '../hooks/useDash'
 import type { PlaybackEngine, PlaybackEngineMode, QualityOption } from './types'
@@ -58,6 +59,7 @@ function useNativeEngine(
 function useHlsEngine(
   videoRef: RefObject<HTMLMediaElement | null>,
   videoUrl: string | null,
+  ladder: PlaybackUrlLadder | undefined,
   isHlsSource: boolean,
   authorPubkey: string | undefined,
   eventId: string | undefined
@@ -66,6 +68,7 @@ function useHlsEngine(
     videoRef,
     videoUrl,
     isHlsSource,
+    ladder,
     authorPubkey,
     eventId,
     'never'
@@ -158,6 +161,7 @@ export function resolvePlaybackMode(
 interface UsePlaybackEngineOptions {
   videoRef: RefObject<HTMLMediaElement | null>
   videoUrl: string | null
+  ladder?: PlaybackUrlLadder
   mime: string
   effectiveUrls: string[]
   videoVariants: VideoVariant[] | undefined
@@ -181,6 +185,7 @@ export function usePlaybackEngine({
   videoRef,
   videoUrl,
   mime,
+  ladder,
   effectiveUrls,
   videoVariants,
   selectedVariantIndex,
@@ -193,7 +198,7 @@ export function usePlaybackEngine({
   const mode = resolvePlaybackMode(mime, effectiveUrls, videoUrl)
 
   const native = useNativeEngine(videoUrl, videoVariants, selectedVariantIndex, handleVariantChange)
-  const hls = useHlsEngine(videoRef, videoUrl, mode === 'hls', authorPubkey, eventId)
+  const hls = useHlsEngine(videoRef, videoUrl, ladder, mode === 'hls', authorPubkey, eventId)
   const dash = useDashEngine(videoRef, videoUrl, mode === 'dash', autoPlay, onError)
 
   if (mode === 'hls') return hls

--- a/src/components/player/hooks/useHls.ts
+++ b/src/components/player/hooks/useHls.ts
@@ -5,6 +5,7 @@ import { createBlossomHlsLoader } from '@/lib/hls-blossom-loader'
 import { isHlsDebugEnabled } from '@/lib/hls-failover-debug'
 import type { BlossomServer, CachingServer } from '@/contexts/AppContext'
 import { getDefaultP2PBlobMesh } from '@/lib/p2p/p2p-blob-mesh'
+import type { PlaybackUrlLadder } from '@/lib/playback-url-ladder'
 
 export interface HlsQualityLevel {
   index: number
@@ -62,6 +63,7 @@ export function useHls(
   videoRef: React.RefObject<HTMLMediaElement | null>,
   src: string | null,
   isHlsSource: boolean,
+  ladder?: PlaybackUrlLadder,
   authorPubkey?: string,
   videoId?: string,
   localhostProxyMode: 'always' | 'master-gated' | 'never' = 'master-gated'
@@ -152,6 +154,7 @@ export function useHls(
         localhostProxyMode,
         p2pHlsBlobCacheEnabled,
         p2pBlobMesh,
+        ladder,
       }),
     })
 
@@ -392,6 +395,7 @@ export function useHls(
     authorPubkey,
     videoId,
     localhostProxyMode,
+    ladder,
   ])
 
   // Set quality level

--- a/src/hooks/useMediaUrls.test.ts
+++ b/src/hooks/useMediaUrls.test.ts
@@ -50,4 +50,31 @@ describe('useMediaUrls', () => {
       expect(result.current.urls).toEqual(['https://cdn.example/2160p.mp4'])
     })
   })
+
+  it('preserves failed URLs when the same video rerenders', async () => {
+    const { result, rerender } = renderHook(
+      ({ urls }: { urls: string[] }) =>
+        useMediaUrls({
+          urls,
+          mediaType: 'video',
+          discoveryEnabled: false,
+        }),
+      {
+        initialProps: {
+          urls: ['https://cdn.example/primary.mp4', 'https://cdn.example/fallback.mp4'],
+        },
+      }
+    )
+
+    await waitFor(() => {
+      expect(result.current.currentUrl).toBe('https://cdn.example/primary.mp4')
+    })
+
+    result.current.moveToNext()
+    rerender({
+      urls: ['https://cdn.example/primary.mp4', 'https://cdn.example/fallback.mp4'],
+    })
+
+    expect(result.current.currentUrl).toBe('https://cdn.example/fallback.mp4')
+  })
 })

--- a/src/hooks/useMediaUrls.test.ts
+++ b/src/hooks/useMediaUrls.test.ts
@@ -2,11 +2,15 @@ import { renderHook, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { useMediaUrls } from './useMediaUrls'
 
-vi.mock('@/lib/media-url-generator', () => ({
+const { generateMediaUrls } = vi.hoisted(() => ({
   generateMediaUrls: vi.fn(({ urls }) => ({
     urls,
     metadata: urls.map(() => ({ source: 'original' })),
   })),
+}))
+
+vi.mock('@/lib/media-url-generator', () => ({
+  generateMediaUrls,
 }))
 
 vi.mock('@/lib/url-discovery', () => ({
@@ -18,63 +22,68 @@ vi.mock('@/lib/url-validator', () => ({
 }))
 
 describe('useMediaUrls', () => {
-  it('resets the active URL when switching to a different video source', async () => {
+  it('replaces the ladder when switching Video Events', async () => {
     const { result, rerender } = renderHook(
       ({ urls, sha256 }: { urls: string[]; sha256: string }) =>
-        useMediaUrls({
-          urls,
-          mediaType: 'video',
-          sha256,
-          discoveryEnabled: false,
-        }),
+        useMediaUrls({ urls, mediaType: 'video', sha256, discoveryEnabled: false }),
       {
         initialProps: {
-          urls: ['https://cdn.example/720p.mp4'],
+          urls: ['https://cdn.example/720p.mp4', 'https://cdn.example/720p-fallback.mp4'],
           sha256: 'hash-720p',
         },
       }
     )
 
-    await waitFor(() => {
-      expect(result.current.currentUrl).toBe('https://cdn.example/720p.mp4')
-    })
+    const firstLadder = result.current.ladder
+    firstLadder.tryNext()
+    expect(firstLadder.currentUrl).toBe('https://cdn.example/720p-fallback.mp4')
 
-    rerender({
-      urls: ['https://cdn.example/2160p.mp4'],
-      sha256: 'hash-2160p',
-    })
+    rerender({ urls: ['https://cdn.example/2160p.mp4'], sha256: 'hash-2160p' })
 
     await waitFor(() => {
-      expect(result.current.currentIndex).toBe(0)
-      expect(result.current.currentUrl).toBe('https://cdn.example/2160p.mp4')
-      expect(result.current.urls).toEqual(['https://cdn.example/2160p.mp4'])
+      expect(result.current.ladder).not.toBe(firstLadder)
+      expect(result.current.ladder.currentUrl).toBe('https://cdn.example/2160p.mp4')
     })
   })
 
-  it('preserves failed URLs when the same video rerenders', async () => {
-    const { result, rerender } = renderHook(
-      ({ urls }: { urls: string[] }) =>
-        useMediaUrls({
-          urls,
-          mediaType: 'video',
-          discoveryEnabled: false,
-        }),
-      {
-        initialProps: {
-          urls: ['https://cdn.example/primary.mp4', 'https://cdn.example/fallback.mp4'],
-        },
-      }
+  it('preserves failed URLs when the same Video Event rerenders', () => {
+    const urls = ['https://cdn.example/primary.mp4', 'https://cdn.example/fallback.mp4']
+    const { result, rerender } = renderHook(() =>
+      useMediaUrls({ urls, mediaType: 'video', discoveryEnabled: false })
     )
 
-    await waitFor(() => {
-      expect(result.current.currentUrl).toBe('https://cdn.example/primary.mp4')
+    result.current.ladder.tryNext()
+    rerender()
+
+    expect(result.current.ladder.currentUrl).toBe('https://cdn.example/fallback.mp4')
+  })
+
+  it('exposes only the ladder, loading state, and recoverable error', () => {
+    const { result } = renderHook(() =>
+      useMediaUrls({
+        urls: ['https://cdn.example/video.mp4'],
+        mediaType: 'video',
+        discoveryEnabled: false,
+      })
+    )
+
+    expect(Object.keys(result.current).sort()).toEqual(['error', 'isLoading', 'ladder'])
+  })
+
+  it('returns a recoverable error when candidate generation fails', () => {
+    generateMediaUrls.mockImplementationOnce(() => {
+      throw new Error('bad media URL')
     })
 
-    result.current.moveToNext()
-    rerender({
-      urls: ['https://cdn.example/primary.mp4', 'https://cdn.example/fallback.mp4'],
-    })
+    const { result } = renderHook(() =>
+      useMediaUrls({
+        urls: ['https://cdn.example/video.mp4'],
+        mediaType: 'video',
+        discoveryEnabled: false,
+      })
+    )
 
-    expect(result.current.currentUrl).toBe('https://cdn.example/fallback.mp4')
+    expect(result.current.error).toEqual(new Error('bad media URL'))
+    expect(result.current.ladder.currentUrl).toBeNull()
   })
 })

--- a/src/hooks/useMediaUrls.ts
+++ b/src/hooks/useMediaUrls.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react'
 import type { MediaUrlOptions, MediaType } from '@/lib/media-url-generator'
 import { PlaybackUrlLadder, type PlaybackUrlLadderOptions } from '@/lib/playback-url-ladder'
 import { discoverUrlsWithCache } from '@/lib/url-discovery'
@@ -6,28 +6,22 @@ import { validateMediaUrl, type ValidationOptions } from '@/lib/url-validator'
 import { isAllowedEventMediaUrl } from '@/lib/media-url-policy'
 import { useAppContextSafe } from '@/hooks/useAppContext'
 import { INDEXER_RELAYS } from '@/constants/relays'
+import type { VideoVariant } from '@/utils/video-event'
 
 export interface UseMediaUrlsOptions extends Omit<MediaUrlOptions, 'blossomServers'> {
+  variants?: VideoVariant[]
   enabled?: boolean
   discoveryEnabled?: boolean
   discoveryRelays?: string[]
   discoveryTimeout?: number
   preValidate?: boolean
   validationOptions?: ValidationOptions
-  onError?: (error: Error) => void
 }
 
 export interface MediaUrlsResult {
   ladder: PlaybackUrlLadder
-  urls: string[]
   isLoading: boolean
-  isDiscovering: boolean
   error: Error | null
-  currentIndex: number
-  currentUrl: string | null
-  moveToNext: () => void
-  reset: () => void
-  hasMore: boolean
 }
 
 /**
@@ -40,6 +34,7 @@ export interface MediaUrlsResult {
 export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
   const {
     urls,
+    variants,
     mediaType,
     sha256,
     kind,
@@ -51,33 +46,32 @@ export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
     discoveryTimeout,
     preValidate,
     validationOptions,
-    onError,
   } = options
   const appContext = useAppContextSafe()
   const config = appContext?.config
-  const blossomServers = useMemo(
-    () => config?.blossomServers ?? [],
-    [config?.blossomServers]
-  )
-  const cachingServers = useMemo(
-    () => config?.cachingServers ?? [],
-    [config?.cachingServers]
-  )
+  const blossomServers = useMemo(() => config?.blossomServers ?? [], [config?.blossomServers])
+  const cachingServers = useMemo(() => config?.cachingServers ?? [], [config?.cachingServers])
   const mediaConfig = config?.media
-  const [error, setError] = useState<Error | null>(null)
   const [isDiscovering, setIsDiscovering] = useState(false)
   const [, update] = useReducer(version => version + 1, 0)
-  const onErrorRef = useRef(onError)
-  onErrorRef.current = onError
 
   const sourceKey = useMemo(
     () =>
-      [enabled, mediaType, sha256 ?? '', kind ?? '', authorPubkey ?? '', ...urls].join('\u0000'),
-    [authorPubkey, enabled, kind, mediaType, sha256, urls]
+      [
+        enabled,
+        mediaType,
+        sha256 ?? '',
+        kind ?? '',
+        authorPubkey ?? '',
+        ...urls,
+        ...(variants ?? []).flatMap(variant => [variant.url, variant.mimeType ?? '']),
+      ].join('\u0000'),
+    [authorPubkey, enabled, kind, mediaType, sha256, urls, variants]
   )
   const ladderOptions = useMemo<PlaybackUrlLadderOptions>(
     () => ({
       urls: enabled ? urls : [],
+      variants: enabled ? variants : undefined,
       blossomServers,
       cachingServers,
       sha256,
@@ -86,7 +80,18 @@ export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
       authorPubkey,
       proxyConfig,
     }),
-    [authorPubkey, blossomServers, cachingServers, enabled, kind, mediaType, proxyConfig, sha256, urls]
+    [
+      authorPubkey,
+      blossomServers,
+      cachingServers,
+      enabled,
+      kind,
+      mediaType,
+      proxyConfig,
+      sha256,
+      urls,
+      variants,
+    ]
   )
   const ladderConfigKey = useMemo(
     () =>
@@ -103,18 +108,25 @@ export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
   const ladderRef = useRef<{ sourceKey: string; ladder: PlaybackUrlLadder } | null>(null)
 
   if (ladderRef.current?.sourceKey !== sourceKey) {
-    ladderRef.current = {
-      sourceKey,
-      ladder: new PlaybackUrlLadder(ladderOptions),
-    }
+    ladderRef.current = { sourceKey, ladder: new PlaybackUrlLadder(ladderOptions) }
   }
 
   const ladder = ladderRef.current.ladder
   const ladderOptionsRef = useRef(ladderOptions)
   ladderOptionsRef.current = ladderOptions
-  const finalDiscoveryEnabled = discoveryEnabled ?? mediaConfig?.failover.discovery.enabled ?? Boolean(sha256)
+  const refreshedConfigRef = useRef({ ladder, key: ladderConfigKey })
+  if (refreshedConfigRef.current.ladder !== ladder) {
+    refreshedConfigRef.current = { ladder, key: ladderConfigKey }
+  }
+  const finalDiscoveryEnabled =
+    discoveryEnabled ?? mediaConfig?.failover.discovery.enabled ?? Boolean(sha256)
   const finalDiscoveryRelays = useMemo(
-    () => [...new Set([...(discoveryRelays ?? config?.relays.map(relay => relay.url) ?? []), ...INDEXER_RELAYS])],
+    () => [
+      ...new Set([
+        ...(discoveryRelays ?? config?.relays.map(relay => relay.url) ?? []),
+        ...INDEXER_RELAYS,
+      ]),
+    ],
     [config?.relays, discoveryRelays]
   )
   const finalDiscoveryTimeout =
@@ -126,8 +138,12 @@ export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
   )
   const ladderUrlsKey = ladder.urls.join('\u0000')
 
+  useEffect(() => ladder.subscribe(update), [ladder])
+
   useEffect(() => {
-    if (ladder.refresh(ladderOptionsRef.current)) update()
+    if (refreshedConfigRef.current.key === ladderConfigKey) return
+    refreshedConfigRef.current = { ladder, key: ladderConfigKey }
+    ladder.refresh(ladderOptionsRef.current)
   }, [ladder, ladderConfigKey])
 
   useEffect(() => {
@@ -144,15 +160,10 @@ export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
     })
       .then(discovered => {
         if (cancelled) return
-        const discoveredUrls = discovered.map(result => result.url).filter(isAllowedEventMediaUrl)
-        if (ladder.merge(discoveredUrls)) update()
+        ladder.merge(discovered.map(result => result.url).filter(isAllowedEventMediaUrl))
       })
-      .catch(discoveryError => {
-        if (cancelled) return
-        const nextError =
-          discoveryError instanceof Error ? discoveryError : new Error('URL discovery failed')
-        setError(nextError)
-        onErrorRef.current?.(nextError)
+      .catch(() => {
+        // Discovery supplements event URLs and must never block playback.
       })
       .finally(() => {
         if (!cancelled) setIsDiscovering(false)
@@ -176,10 +187,7 @@ export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
       }))
     ).then(results => {
       if (cancelled) return
-      const validUrls = results.filter(result => result.isValid).map(result => result.url)
-      if (validUrls.length === 0) return
-      ladder.promote(validUrls)
-      update()
+      ladder.promote(results.filter(result => result.isValid).map(result => result.url))
     })
 
     return () => {
@@ -187,42 +195,7 @@ export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
     }
   }, [enabled, finalPreValidate, finalValidationOptions, ladder, ladderUrlsKey])
 
-  const moveToNext = useCallback(() => {
-    if (ladder.tryNext()) update()
-  }, [ladder])
-  const reset = useCallback(() => {
-    ladder.reset()
-    update()
-  }, [ladder])
-
-  return {
-    ladder,
-    urls: ladder.urls,
-    isLoading: false,
-    isDiscovering,
-    error,
-    currentIndex: ladder.currentIndex,
-    currentUrl: ladder.currentUrl,
-    moveToNext,
-    reset,
-    hasMore: ladder.hasMore,
-  }
-}
-
-export function useMediaUrlsWithAutoRetry(options: UseMediaUrlsOptions) {
-  const result = useMediaUrls(options)
-  const onErrorRef = useRef(options.onError)
-  onErrorRef.current = options.onError
-
-  const handleError = useCallback(() => {
-    if (result.hasMore) {
-      result.moveToNext()
-      return
-    }
-    onErrorRef.current?.(new Error('All media URLs failed'))
-  }, [result])
-
-  return { ...result, handleError }
+  return { ladder, isLoading: isDiscovering, error: ladder.error }
 }
 
 export type { MediaType }

--- a/src/hooks/useMediaUrls.ts
+++ b/src/hooks/useMediaUrls.ts
@@ -1,62 +1,45 @@
-/**
- * useMediaUrls Hook
- *
- * React integration for media URL failover system.
- * Provides automatic URL discovery and failover for any media type.
- */
-
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import {
-  generateMediaUrls,
-  type MediaUrlOptions,
-  type GeneratedUrls,
-} from '@/lib/media-url-generator'
-import { discoverUrlsWithCache, type DiscoveryOptions } from '@/lib/url-discovery'
+import { useCallback, useEffect, useMemo, useReducer, useRef, useState } from 'react'
+import type { MediaUrlOptions, MediaType } from '@/lib/media-url-generator'
+import { PlaybackUrlLadder, type PlaybackUrlLadderOptions } from '@/lib/playback-url-ladder'
+import { discoverUrlsWithCache } from '@/lib/url-discovery'
 import { validateMediaUrl, type ValidationOptions } from '@/lib/url-validator'
 import { isAllowedEventMediaUrl } from '@/lib/media-url-policy'
 import { useAppContextSafe } from '@/hooks/useAppContext'
 import { INDEXER_RELAYS } from '@/constants/relays'
 
 export interface UseMediaUrlsOptions extends Omit<MediaUrlOptions, 'blossomServers'> {
-  enabled?: boolean // Enable URL generation (default: true)
-  discoveryEnabled?: boolean // Enable relay discovery for kind 1063 (default: true when sha256 provided)
-  discoveryRelays?: string[] // Relays for discovery
-  discoveryTimeout?: number // Discovery timeout (default: 10s)
-  preValidate?: boolean // Pre-validate URLs before returning (default: false)
-  validationOptions?: ValidationOptions // Validation options
-  authorPubkey?: string // Author pubkey (npub or hex) for AS query parameter
+  enabled?: boolean
+  discoveryEnabled?: boolean
+  discoveryRelays?: string[]
+  discoveryTimeout?: number
+  preValidate?: boolean
+  validationOptions?: ValidationOptions
   onError?: (error: Error) => void
 }
 
 export interface MediaUrlsResult {
-  urls: string[] // All available URLs
+  ladder: PlaybackUrlLadder
+  urls: string[]
   isLoading: boolean
-  isDiscovering: boolean // Currently discovering URLs
+  isDiscovering: boolean
   error: Error | null
-  currentIndex: number // Which URL is active
-  currentUrl: string | null // Current active URL
-  moveToNext: () => void // Try next URL
-  reset: () => void // Start over
-  hasMore: boolean // Are there more URLs to try?
+  currentIndex: number
+  currentUrl: string | null
+  moveToNext: () => void
+  reset: () => void
+  hasMore: boolean
 }
 
 /**
- * Hook for managing media URLs with automatic failover and discovery
+ * React binding for a single Video Event's playback URL ladder.
  *
- * Usage:
- * ```tsx
- * const { urls, currentUrl, moveToNext, isLoading } = useMediaUrls({
- *   urls: videoUrls,
- *   mediaType: 'video',
- *   sha256: videoHash,
- *   discoveryEnabled: true,
- *   discoveryRelays: relays,
- * })
- * ```
+ * URL generation, discovery, validation, and failover all mutate the same
+ * plain ladder instance. Consumers that need the underlying playback policy
+ * (notably the HLS loader) receive that instance from the result.
  */
 export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
   const {
-    urls: originalUrls,
+    urls,
     mediaType,
     sha256,
     kind,
@@ -70,372 +53,176 @@ export function useMediaUrls(options: UseMediaUrlsOptions): MediaUrlsResult {
     validationOptions,
     onError,
   } = options
-
-  // Get configuration from AppContext (may be undefined in embed context)
   const appContext = useAppContextSafe()
   const config = appContext?.config
-
-  // Store onError in ref to avoid it as a dependency
-  const onErrorRef = useRef(onError)
-  useEffect(() => {
-    onErrorRef.current = onError
-  }, [onError])
-
-  // Memoize blossomServers to prevent unnecessary re-renders
-  const blossomServers = useMemo(() => config?.blossomServers || [], [config?.blossomServers])
-
-  // Memoize cachingServers to prevent unnecessary re-renders
-  const cachingServers = useMemo(() => config?.cachingServers || [], [config?.cachingServers])
-
-  // Use media config from context if not provided in options
+  const blossomServers = useMemo(
+    () => config?.blossomServers ?? [],
+    [config?.blossomServers]
+  )
+  const cachingServers = useMemo(
+    () => config?.cachingServers ?? [],
+    [config?.cachingServers]
+  )
   const mediaConfig = config?.media
-
-  // Memoize all computed config values to prevent unnecessary re-renders
-  // Enable discovery by default when sha256 is available (required for kind 1063 lookup)
-  const finalDiscoveryEnabled = useMemo(
-    () => discoveryEnabled ?? mediaConfig?.failover.discovery.enabled ?? !!sha256,
-    [discoveryEnabled, mediaConfig?.failover.discovery.enabled, sha256]
-  )
-
-  // Use user's relays + indexer relays for discovery
-  // Indexer relays are good for finding kind 1063 file metadata events
-  const finalDiscoveryRelays = useMemo(() => {
-    const userRelays = discoveryRelays ?? config?.relays.map(r => r.url) ?? []
-    // Combine user relays with indexer relays, deduplicate
-    const allRelays = [...new Set([...userRelays, ...INDEXER_RELAYS])]
-    return allRelays
-  }, [discoveryRelays, config?.relays])
-
-  const finalDiscoveryTimeout = useMemo(
-    () => discoveryTimeout ?? mediaConfig?.failover.discovery.timeout ?? 10000,
-    [discoveryTimeout, mediaConfig?.failover.discovery.timeout]
-  )
-
-  const finalPreValidate = useMemo(
-    () => preValidate ?? mediaConfig?.failover.validation.enabled ?? false,
-    [preValidate, mediaConfig?.failover.validation.enabled]
-  )
-
-  const finalValidationOptions = useMemo(
-    () =>
-      validationOptions ?? {
-        timeout: mediaConfig?.failover.validation.timeout ?? 5000,
-      },
-    [validationOptions, mediaConfig?.failover.validation.timeout]
-  )
-
-  const [generatedUrls, setGeneratedUrls] = useState<GeneratedUrls>({
-    urls: [],
-    metadata: [],
-  })
-  const [currentIndex, setCurrentIndex] = useState(0)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isDiscovering, setIsDiscovering] = useState(false)
   const [error, setError] = useState<Error | null>(null)
+  const [isDiscovering, setIsDiscovering] = useState(false)
+  const [, update] = useReducer(version => version + 1, 0)
+  const onErrorRef = useRef(onError)
+  onErrorRef.current = onError
 
-  // Serialize URL arrays for stable comparison
-  const originalUrlsKey = useMemo(() => originalUrls.join('|'), [originalUrls])
-  const sourceMediaKey = useMemo(
-    () => [mediaType, kind ?? '', sha256 ?? '', authorPubkey ?? '', originalUrlsKey].join('|'),
-    [authorPubkey, kind, mediaType, originalUrlsKey, sha256]
+  const sourceKey = useMemo(
+    () =>
+      [enabled, mediaType, sha256 ?? '', kind ?? '', authorPubkey ?? '', ...urls].join('\u0000'),
+    [authorPubkey, enabled, kind, mediaType, sha256, urls]
   )
-  const previousSourceMediaKeyRef = useRef<string | null>(null)
-  const blossomServersKey = useMemo(
-    () => blossomServers.map(s => s.url).join('|'),
-    [blossomServers]
+  const ladderOptions = useMemo<PlaybackUrlLadderOptions>(
+    () => ({
+      urls: enabled ? urls : [],
+      blossomServers,
+      cachingServers,
+      sha256,
+      kind,
+      mediaType,
+      authorPubkey,
+      proxyConfig,
+    }),
+    [authorPubkey, blossomServers, cachingServers, enabled, kind, mediaType, proxyConfig, sha256, urls]
   )
-  const cachingServersKey = useMemo(
-    () => cachingServers.map(s => s.url).join('|'),
-    [cachingServers]
+  const ladderConfigKey = useMemo(
+    () =>
+      [
+        sourceKey,
+        proxyConfig?.enabled,
+        proxyConfig?.maxSize?.width ?? '',
+        proxyConfig?.maxSize?.height ?? '',
+        ...blossomServers.map(server => `${server.url}:${server.tags.join(',')}`),
+        ...cachingServers.map(server => server.url),
+      ].join('\u0000'),
+    [blossomServers, cachingServers, proxyConfig, sourceKey]
   )
+  const ladderRef = useRef<{ sourceKey: string; ladder: PlaybackUrlLadder } | null>(null)
 
-  // Generate URLs from original URLs + mirrors + proxies
+  if (ladderRef.current?.sourceKey !== sourceKey) {
+    ladderRef.current = {
+      sourceKey,
+      ladder: new PlaybackUrlLadder(ladderOptions),
+    }
+  }
+
+  const ladder = ladderRef.current.ladder
+  const ladderOptionsRef = useRef(ladderOptions)
+  ladderOptionsRef.current = ladderOptions
+  const finalDiscoveryEnabled = discoveryEnabled ?? mediaConfig?.failover.discovery.enabled ?? Boolean(sha256)
+  const finalDiscoveryRelays = useMemo(
+    () => [...new Set([...(discoveryRelays ?? config?.relays.map(relay => relay.url) ?? []), ...INDEXER_RELAYS])],
+    [config?.relays, discoveryRelays]
+  )
+  const finalDiscoveryTimeout =
+    discoveryTimeout ?? mediaConfig?.failover.discovery.timeout ?? 10_000
+  const finalPreValidate = preValidate ?? mediaConfig?.failover.validation.enabled ?? false
+  const finalValidationOptions = useMemo(
+    () => validationOptions ?? { timeout: mediaConfig?.failover.validation.timeout ?? 5_000 },
+    [mediaConfig?.failover.validation.timeout, validationOptions]
+  )
+  const ladderUrlsKey = ladder.urls.join('\u0000')
+
   useEffect(() => {
-    if (!enabled || originalUrls.length === 0) {
-      setIsLoading(false)
-      return
-    }
+    if (ladder.refresh(ladderOptionsRef.current)) update()
+  }, [ladder, ladderConfigKey])
 
-    try {
-      const generated = generateMediaUrls({
-        urls: originalUrls,
-        blossomServers,
-        cachingServers,
-        sha256,
-        kind,
-        mediaType,
-        proxyConfig,
-        authorPubkey,
-      })
-
-      const sourceMediaChanged = previousSourceMediaKeyRef.current !== sourceMediaKey
-      previousSourceMediaKeyRef.current = sourceMediaKey
-
-      setGeneratedUrls(prev => {
-        // If we already have URLs and the current one is still in the new list,
-        // merge new URLs without disrupting playback. This prevents glitches when
-        // config changes (e.g. blossom servers loading from relays after video started).
-        if (!sourceMediaChanged && prev.urls.length > 0) {
-          const existingSet = new Set(prev.urls)
-          const newUrls = generated.urls.filter(u => !existingSet.has(u))
-          if (newUrls.length > 0) {
-            // Append newly discovered mirror/proxy URLs without resetting index
-            return {
-              urls: [...prev.urls, ...newUrls],
-              metadata: [...prev.metadata, ...newUrls.map(() => ({ source: 'mirror' as const }))],
-            }
-          }
-          // No new URLs, keep everything as-is (don't reset index)
-          return prev
-        }
-        // First load or media source change: full reset. This is required when
-        // switching between quality variants, where the first generated URL must
-        // become active instead of being appended behind the previous stream.
-        setCurrentIndex(0)
-        return generated
-      })
-      setIsLoading(false)
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error('Failed to generate URLs')
-      setError(error)
-      setIsLoading(false)
-      onErrorRef.current?.(error)
-    }
-  }, [
-    originalUrlsKey,
-    sourceMediaKey,
-    originalUrls,
-    mediaType,
-    sha256,
-    kind,
-    proxyConfig,
-    authorPubkey,
-    enabled,
-    blossomServersKey,
-    blossomServers,
-    cachingServersKey,
-    cachingServers,
-  ])
-
-  // Serialize discovery relays for stable comparison
-  const discoveryRelaysKey = useMemo(() => finalDiscoveryRelays.join('|'), [finalDiscoveryRelays])
-
-  // Discover alternative URLs via kind 1063 lookup if enabled
   useEffect(() => {
-    if (!enabled || !finalDiscoveryEnabled || !sha256 || finalDiscoveryRelays.length === 0) {
-      return
-    }
+    if (!enabled || !finalDiscoveryEnabled || !sha256 || finalDiscoveryRelays.length === 0) return
 
     let cancelled = false
+    setIsDiscovering(true)
 
-    const discover = async () => {
-      setIsDiscovering(true)
-
-      if (import.meta.env.DEV) {
-        console.log(
-          `[useMediaUrls] Discovering kind 1063 for ${mediaType} hash=${sha256.slice(0, 8)}...`
-        )
-      }
-
-      try {
-        const discoveryOptions: DiscoveryOptions = {
-          sha256,
-          relays: finalDiscoveryRelays,
-          timeout: finalDiscoveryTimeout,
-          maxResults: 20,
-        }
-
-        const discovered = await discoverUrlsWithCache(discoveryOptions)
-
-        if (cancelled) return
-
-        if (discovered.length > 0) {
-          const discoveredUrls = discovered.map(d => d.url).filter(isAllowedEventMediaUrl)
-
-          setGeneratedUrls(prev => {
-            // Filter out duplicates
-            const existingUrls = new Set(prev.urls)
-            const newUrls = discoveredUrls.filter(url => !existingUrls.has(url))
-
-            if (newUrls.length === 0) return prev
-
-            return {
-              urls: [...prev.urls, ...newUrls],
-              metadata: [
-                ...prev.metadata,
-                ...newUrls.map(() => ({ source: 'discovered' as const })),
-              ],
-            }
-          })
-
-          if (import.meta.env.DEV) {
-            console.log(`Discovered ${discovered.length} alternative URLs for ${mediaType}`)
-          }
-        }
-      } catch (err) {
-        if (cancelled) return
-
-        const error = err instanceof Error ? err : new Error('URL discovery failed')
-        console.error('URL discovery error:', error)
-        // Don't set error state for discovery failures - just log them
-      } finally {
-        if (!cancelled) {
-          setIsDiscovering(false)
-        }
-      }
-    }
-
-    discover()
-
-    return () => {
-      cancelled = true
-    }
-  }, [
-    enabled,
-    finalDiscoveryEnabled,
-    sha256,
-    discoveryRelaysKey,
-    finalDiscoveryRelays,
-    finalDiscoveryTimeout,
-    mediaType,
-  ])
-
-  // Serialize generated URLs for stable comparison
-  const generatedUrlsKey = useMemo(() => generatedUrls.urls.join('|'), [generatedUrls.urls])
-
-  // Pre-validate URLs if enabled
-  useEffect(() => {
-    if (!enabled || !finalPreValidate || generatedUrls.urls.length === 0) {
-      return
-    }
-
-    let cancelled = false
-
-    const validate = async () => {
-      const validUrls: string[] = []
-
-      // Validate up to first 5 URLs
-      const urlsToValidate = generatedUrls.urls.slice(0, 5)
-
-      for (const url of urlsToValidate) {
-        if (cancelled) break
-
-        try {
-          const isValid = await validateMediaUrl(url, finalValidationOptions)
-          if (isValid) {
-            validUrls.push(url)
-          }
-        } catch (err) {
-          console.debug(`Pre-validation failed for ${url}:`, err)
-        }
-      }
-
-      if (cancelled) return
-
-      // If we found valid URLs, reorder to put them first
-      if (validUrls.length > 0) {
-        setGeneratedUrls(prev => {
-          const validSet = new Set(validUrls)
-          const otherUrls = prev.urls.filter(url => !validSet.has(url))
-
-          return {
-            urls: [...validUrls, ...otherUrls],
-            metadata: prev.metadata, // Keep original metadata order
-          }
-        })
-
-        if (import.meta.env.DEV) {
-          console.log(`Pre-validated ${validUrls.length} URLs for ${mediaType}`)
-        }
-      }
-    }
-
-    validate()
-
-    return () => {
-      cancelled = true
-    }
-  }, [
-    enabled,
-    finalPreValidate,
-    generatedUrlsKey,
-    generatedUrls.urls,
-    mediaType,
-    finalValidationOptions,
-  ])
-
-  // Move to next URL
-  const moveToNext = useCallback(() => {
-    setCurrentIndex(prev => {
-      if (prev < generatedUrls.urls.length - 1) {
-        return prev + 1
-      }
-      return prev
+    void discoverUrlsWithCache({
+      sha256,
+      relays: finalDiscoveryRelays,
+      timeout: finalDiscoveryTimeout,
+      maxResults: 20,
     })
-  }, [generatedUrls.urls.length])
+      .then(discovered => {
+        if (cancelled) return
+        const discoveredUrls = discovered.map(result => result.url).filter(isAllowedEventMediaUrl)
+        if (ladder.merge(discoveredUrls)) update()
+      })
+      .catch(discoveryError => {
+        if (cancelled) return
+        const nextError =
+          discoveryError instanceof Error ? discoveryError : new Error('URL discovery failed')
+        setError(nextError)
+        onErrorRef.current?.(nextError)
+      })
+      .finally(() => {
+        if (!cancelled) setIsDiscovering(false)
+      })
 
-  // Reset to first URL
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, finalDiscoveryEnabled, finalDiscoveryRelays, finalDiscoveryTimeout, ladder, sha256])
+
+  useEffect(() => {
+    if (!enabled || !finalPreValidate || ladder.urls.length === 0) return
+
+    let cancelled = false
+    const candidates = ladder.urls.slice(0, 5)
+
+    void Promise.all(
+      candidates.map(async url => ({
+        url,
+        isValid: await validateMediaUrl(url, finalValidationOptions).catch(() => false),
+      }))
+    ).then(results => {
+      if (cancelled) return
+      const validUrls = results.filter(result => result.isValid).map(result => result.url)
+      if (validUrls.length === 0) return
+      ladder.promote(validUrls)
+      update()
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [enabled, finalPreValidate, finalValidationOptions, ladder, ladderUrlsKey])
+
+  const moveToNext = useCallback(() => {
+    if (ladder.tryNext()) update()
+  }, [ladder])
   const reset = useCallback(() => {
-    setCurrentIndex(0)
-    setError(null)
-  }, [])
-
-  const currentUrl = generatedUrls.urls[currentIndex] || null
-  const hasMore = currentIndex < generatedUrls.urls.length - 1
+    ladder.reset()
+    update()
+  }, [ladder])
 
   return {
-    urls: generatedUrls.urls,
-    isLoading,
+    ladder,
+    urls: ladder.urls,
+    isLoading: false,
     isDiscovering,
     error,
-    currentIndex,
-    currentUrl,
+    currentIndex: ladder.currentIndex,
+    currentUrl: ladder.currentUrl,
     moveToNext,
     reset,
-    hasMore,
+    hasMore: ladder.hasMore,
   }
 }
 
-/**
- * Hook variant that automatically tries next URL on error
- *
- * Usage:
- * ```tsx
- * const { currentUrl, handleError } = useMediaUrlsWithAutoRetry({
- *   urls: videoUrls,
- *   mediaType: 'video',
- * })
- *
- * <video
- *   src={currentUrl}
- *   onError={handleError}
- * />
- * ```
- */
 export function useMediaUrlsWithAutoRetry(options: UseMediaUrlsOptions) {
   const result = useMediaUrls(options)
-  const { moveToNext, hasMore, currentIndex, urls } = result
-
-  // Store onError in ref to avoid it as a dependency
   const onErrorRef = useRef(options.onError)
-  useEffect(() => {
-    onErrorRef.current = options.onError
-  }, [options.onError])
+  onErrorRef.current = options.onError
 
   const handleError = useCallback(() => {
-    if (hasMore) {
-      if (import.meta.env.DEV) {
-        console.log(`Auto-retrying with next URL (${currentIndex + 1}/${urls.length})`)
-      }
-      moveToNext()
-    } else {
-      console.warn('All URLs failed, no more alternatives available')
-      onErrorRef.current?.(new Error('All media URLs failed'))
+    if (result.hasMore) {
+      result.moveToNext()
+      return
     }
-  }, [hasMore, moveToNext, currentIndex, urls.length])
+    onErrorRef.current?.(new Error('All media URLs failed'))
+  }, [result])
 
-  return {
-    ...result,
-    handleError,
-  }
+  return { ...result, handleError }
 }
+
+export type { MediaType }

--- a/src/hooks/useValidUrl.ts
+++ b/src/hooks/useValidUrl.ts
@@ -25,7 +25,7 @@ export function useValidUrl(options: UseValidUrlOptions): UseValidUrlResult {
   const { urls, resourceType = 'video', enabled = true, sha256 } = options
 
   // Use new media URL failover system
-  const { currentUrl, isLoading, error } = useMediaUrls({
+  const { ladder, isLoading, error } = useMediaUrls({
     urls,
     mediaType: resourceType as MediaType,
     sha256,
@@ -33,7 +33,7 @@ export function useValidUrl(options: UseValidUrlOptions): UseValidUrlResult {
   })
 
   return {
-    validUrl: currentUrl,
+    validUrl: ladder.currentUrl,
     isValidating: isLoading,
     error,
   }

--- a/src/hooks/useVideoPrefetch.ts
+++ b/src/hooks/useVideoPrefetch.ts
@@ -39,7 +39,7 @@ const PROXY_CONFIG = { enabled: true }
 export function useVideoPrefetch({ video, enabled, priority = 1 }: UseVideoPrefetchOptions): void {
   // Resolve the neighbor URL ahead of time. This also primes the sha256-keyed
   // discovery cache, so when the singleton resolves the same video it is instant.
-  const { currentUrl } = useMediaUrls({
+  const { ladder } = useMediaUrls({
     urls: video?.urls ?? [],
     mediaType: 'video',
     sha256: video?.x,
@@ -48,6 +48,7 @@ export function useVideoPrefetch({ video, enabled, priority = 1 }: UseVideoPrefe
     proxyConfig: PROXY_CONFIG,
     enabled: enabled && !!video,
   })
+  const currentUrl = ladder.currentUrl
 
   const sha256 = video?.x
 

--- a/src/lib/hls-blossom-loader.ts
+++ b/src/lib/hls-blossom-loader.ts
@@ -9,7 +9,7 @@ import type {
 } from 'hls.js'
 import type { BlossomServer, CachingServer } from '@/contexts/AppContext'
 import { extractBlossomHash } from '@/lib/blossom-url'
-import { generateMediaUrls } from '@/lib/media-url-generator'
+import { PlaybackUrlLadder } from '@/lib/playback-url-ladder'
 import { emitHlsFailoverDebug, isHlsDebugEnabled } from '@/lib/hls-failover-debug'
 import { getDefaultVerifiedBlobCache, type VerifiedBlobCache } from '@/lib/p2p/verified-blob-cache'
 import { isAllowedEventMediaUrl } from '@/lib/media-url-policy'
@@ -25,6 +25,7 @@ interface HlsBlossomLoaderOptions {
   p2pHlsBlobCacheEnabled?: boolean
   verifiedBlobCache?: VerifiedBlobCache
   p2pBlobMesh?: P2PBlobMesh
+  ladder?: PlaybackUrlLadder
 }
 
 function logHlsLoader(message: string, details: Record<string, unknown>) {
@@ -64,28 +65,6 @@ function copyLoaderStats(target: LoaderStats, source: LoaderStats) {
   copyTiming(target.buffering, source.buffering)
 }
 
-function buildFallbackUrls(url: string, options: HlsBlossomLoaderOptions): string[] {
-  const { sha256 } = extractBlossomHash(url)
-  if (!sha256) {
-    return [url]
-  }
-
-  const generated = generateMediaUrls({
-    urls: [url],
-    blossomServers: options.blossomServers,
-    cachingServers: options.cachingServers,
-    sha256,
-    mediaType: 'video',
-    authorPubkey: options.authorPubkey,
-    proxyConfig: { enabled: true },
-  }).urls
-
-  if (generated.length === 0) {
-    return [url]
-  }
-
-  return generated
-}
 
 function isBlockedEventUrl(url: string): boolean {
   return !isAllowedEventMediaUrl(url)
@@ -170,6 +149,16 @@ function createCacheHitStats(baseStats: LoaderStats, bytes: Uint8Array): LoaderS
 }
 
 export function createBlossomHlsLoader(options: HlsBlossomLoaderOptions) {
+  const ladder =
+    options.ladder ??
+    new PlaybackUrlLadder({
+      urls: options.masterUrl ? [options.masterUrl] : [],
+      blossomServers: options.blossomServers,
+      cachingServers: options.cachingServers,
+      mediaType: 'video',
+      authorPubkey: options.authorPubkey,
+      proxyConfig: { enabled: true },
+    })
   const BaseLoader = Hls.DefaultConfig.loader as new (config: HlsConfig) => Loader<LoaderContext>
   let masterServedFromLocalhost: boolean | null = null
   const verifiedBlobCache = options.verifiedBlobCache ?? getDefaultVerifiedBlobCache()
@@ -215,7 +204,16 @@ export function createBlossomHlsLoader(options: HlsBlossomLoaderOptions) {
       const isMasterRequest =
         normalizedMasterUrl !== undefined && normalizedMasterUrl === normalizedRequestUrl
 
-      let candidates = buildFallbackUrls(context.url, options)
+      let candidates = ladder.candidatesFor(context.url)
+      if (candidates.length === 0) {
+        callbacks.onError(
+          { code: 410, text: 'All HLS media URL candidates failed' },
+          context,
+          null,
+          this.stats
+        )
+        return
+      }
       const localhostMode = options.localhostProxyMode ?? 'master-gated'
       const candidatesBeforeFiltering = candidates
 
@@ -452,6 +450,7 @@ export function createBlossomHlsLoader(options: HlsBlossomLoaderOptions) {
             callbacks.onSuccess(response, this.stats, successContext, networkDetails)
           },
           onError: (response, errorContext, networkDetails, stats) => {
+            ladder.onError(candidateUrl, isMasterRequest ? 'manifest' : 'segment')
             if (stats) {
               copyLoaderStats(this.stats, stats)
             }
@@ -489,6 +488,7 @@ export function createBlossomHlsLoader(options: HlsBlossomLoaderOptions) {
             callbacks.onError(response, errorContext, networkDetails, this.stats)
           },
           onTimeout: (stats, timeoutContext, networkDetails) => {
+            ladder.onError(candidateUrl, isMasterRequest ? 'manifest' : 'segment')
             copyLoaderStats(this.stats, stats)
             logHlsLoader('candidate timeout', {
               videoId: options.videoId,

--- a/src/lib/playback-url-ladder.test.ts
+++ b/src/lib/playback-url-ladder.test.ts
@@ -1,14 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { PlaybackUrlLadder } from './playback-url-ladder'
-
 describe('PlaybackUrlLadder', () => {
-  const createLadder = (urls = ['https://primary.example/video.mp4', 'https://fallback.example/video.mp4']) =>
+  const createLadder = (
+    urls = ['https://primary.example/video.mp4', 'https://fallback.example/video.mp4']
+  ) =>
     new PlaybackUrlLadder({
       urls,
       blossomServers: [],
       mediaType: 'video',
     })
-
   it('advances after an active URL fails and does not retry it after refresh', () => {
     const ladder = createLadder()
 

--- a/src/lib/playback-url-ladder.test.ts
+++ b/src/lib/playback-url-ladder.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { PlaybackUrlLadder } from './playback-url-ladder'
+
+describe('PlaybackUrlLadder', () => {
+  const createLadder = (urls = ['https://primary.example/video.mp4', 'https://fallback.example/video.mp4']) =>
+    new PlaybackUrlLadder({
+      urls,
+      blossomServers: [],
+      mediaType: 'video',
+    })
+
+  it('advances after an active URL fails and does not retry it after refresh', () => {
+    const ladder = createLadder()
+
+    expect(ladder.currentUrl).toBe('https://primary.example/video.mp4')
+    expect(ladder.onError()).toBe(true)
+    expect(ladder.currentUrl).toBe('https://fallback.example/video.mp4')
+    expect(ladder.failedUrls).toEqual(['https://primary.example/video.mp4'])
+
+    ladder.refresh({
+      urls: ['https://primary.example/video.mp4', 'https://fallback.example/video.mp4'],
+      blossomServers: [],
+      mediaType: 'video',
+    })
+
+    expect(ladder.currentUrl).toBe('https://fallback.example/video.mp4')
+    expect(ladder.urls).toEqual([
+      'https://primary.example/video.mp4',
+      'https://fallback.example/video.mp4',
+    ])
+  })
+
+  it('merges discovered candidates after generated candidates without duplication', () => {
+    const ladder = createLadder(['https://primary.example/video.mp4'])
+
+    expect(
+      ladder.merge(
+        ['https://primary.example/video.mp4', 'https://discovered.example/video.mp4'],
+        'discovered'
+      )
+    ).toBe(true)
+    expect(ladder.urls).toEqual([
+      'https://primary.example/video.mp4',
+      'https://discovered.example/video.mp4',
+    ])
+    expect(ladder.hasMore).toBe(true)
+    expect(ladder.tryNext()).toBe(true)
+    expect(ladder.currentUrl).toBe('https://discovered.example/video.mp4')
+  })
+
+  it('keeps segment failover candidates aligned with the shared failed URL set', () => {
+    const segment =
+      'https://media.example/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef.m4s'
+    const ladder = createLadder()
+
+    expect(ladder.candidatesFor(segment)).toEqual([segment])
+    ladder.onError(segment, 'segment')
+    expect(ladder.candidatesFor(segment)).toEqual([])
+  })
+})

--- a/src/lib/playback-url-ladder.ts
+++ b/src/lib/playback-url-ladder.ts
@@ -1,0 +1,184 @@
+import type { BlossomServer, CachingServer } from '@/contexts/AppContext'
+import { extractBlossomHash } from '@/lib/blossom-url'
+import {
+  generateMediaUrls,
+  type GeneratedUrls,
+  type MediaType,
+  type MediaUrlOptions,
+  type UrlMetadata,
+  type UrlSource,
+} from './media-url-generator'
+
+export interface PlaybackUrlLadderOptions {
+  urls: string[]
+  blossomServers: BlossomServer[]
+  cachingServers?: CachingServer[]
+  sha256?: string
+  kind?: number
+  mediaType: MediaType
+  authorPubkey?: string
+  proxyConfig?: MediaUrlOptions['proxyConfig']
+}
+
+export type PlaybackErrorKind = 'manifest' | 'segment' | 'media' | 'network' | string
+
+/**
+ * The mutable URL selection policy for one Video Event.
+ *
+ * It stays independent of React and HLS.js: callers can retain one instance
+ * across renders and report failed candidates from either playback path.
+ */
+export class PlaybackUrlLadder {
+  private options: PlaybackUrlLadderOptions
+  private _urls: string[]
+  private _metadata: UrlMetadata[]
+  private _index = 0
+  private readonly failed = new Set<string>()
+
+  constructor(options: PlaybackUrlLadderOptions) {
+    this.options = options
+    const generated = this.generate(options.urls, options.sha256)
+    this._urls = generated.urls
+    this._metadata = generated.metadata
+  }
+
+  get urls(): string[] {
+    return this._urls
+  }
+
+  get metadata(): UrlMetadata[] {
+    return this._metadata
+  }
+
+  get currentIndex(): number {
+    return this._index
+  }
+
+  get currentUrl(): string | null {
+    return this._urls[this._index] ?? null
+  }
+
+  get hasMore(): boolean {
+    return this.findNextIndex(this._index + 1) !== -1
+  }
+
+  get failedUrls(): string[] {
+    return [...this.failed]
+  }
+
+  isFailed(url: string): boolean {
+    return this.failed.has(url)
+  }
+
+  /** Report the active candidate as failed and advance to the next unfailed candidate. */
+  tryNext(): boolean {
+    const current = this.currentUrl
+    if (current) this.failed.add(current)
+    return this.advance()
+  }
+
+  /**
+   * Record a failed candidate from the player or HLS loader. A failure advances
+   * only when it belongs to the active URL; segment failures remain available
+   * to the requesting loader through {@link candidatesFor}.
+   */
+  onError(url = this.currentUrl ?? undefined, _kind?: PlaybackErrorKind): boolean {
+    if (!url) return false
+    const isCurrent = url === this.currentUrl
+    this.failed.add(url)
+    return isCurrent ? this.advance() : false
+  }
+
+  /** Start again at the first candidate that has not already failed. */
+  reset(): void {
+    const first = this.findNextIndex(0)
+    this._index = first === -1 ? this._urls.length : first
+  }
+
+  /**
+   * Re-apply the shared generation policy when the configuration changes. New
+   * candidates append without disrupting the active candidate or failed set.
+   */
+  refresh(options: PlaybackUrlLadderOptions): boolean {
+    this.options = options
+    const generated = this.generate(options.urls, options.sha256)
+    return this.appendNew(generated.urls, index => generated.metadata[index])
+  }
+
+  /** Merge asynchronous discovery candidates after the generated candidates. */
+  merge(urls: string[], source: UrlSource = 'discovered'): boolean {
+    return this.appendNew(urls, () => ({ source }))
+  }
+
+  /** Promote known-good candidates while preserving the current URL. */
+  promote(urls: string[]): void {
+    const current = this.currentUrl
+    const promoted = new Set(urls.filter(url => this._urls.includes(url) && !this.failed.has(url)))
+    if (promoted.size === 0) return
+
+    const orderedIndexes = [
+      ...this._urls.flatMap((url, index) => (promoted.has(url) ? [index] : [])),
+      ...this._urls.flatMap((url, index) => (promoted.has(url) ? [] : [index])),
+    ]
+    this._urls = orderedIndexes.map(index => this._urls[index])
+    this._metadata = orderedIndexes.map(index => this._metadata[index])
+    this._index = current ? this._urls.indexOf(current) : this.findNextIndex(0)
+  }
+
+  /**
+   * Generate fallback candidates for a manifest or segment through the same
+   * policy and remove candidates already known to have failed.
+   */
+  candidatesFor(url: string): string[] {
+    const { sha256 } = extractBlossomHash(url)
+    const candidates = sha256 ? this.generate([url], sha256).urls : [url]
+    return candidates.filter(candidate => !this.failed.has(candidate))
+  }
+
+  private generate(urls: string[], sha256?: string): GeneratedUrls {
+    if (urls.length === 0) return { urls: [], metadata: [] }
+
+    return generateMediaUrls({
+      urls,
+      blossomServers: this.options.blossomServers,
+      cachingServers: this.options.cachingServers,
+      sha256,
+      kind: this.options.kind,
+      mediaType: this.options.mediaType,
+      authorPubkey: this.options.authorPubkey,
+      proxyConfig: this.options.proxyConfig,
+    })
+  }
+
+  private advance(): boolean {
+    const next = this.findNextIndex(this._index + 1)
+    if (next === -1) return false
+    this._index = next
+    return true
+  }
+
+  private findNextIndex(start: number): number {
+    for (let index = start; index < this._urls.length; index += 1) {
+      if (!this.failed.has(this._urls[index])) return index
+    }
+    return -1
+  }
+
+  private appendNew(urls: string[], metadataFor: (index: number) => UrlMetadata): boolean {
+    const known = new Set(this._urls)
+    const newUrls: string[] = []
+    const newMetadata: UrlMetadata[] = []
+
+    urls.forEach((url, index) => {
+      if (known.has(url)) return
+      known.add(url)
+      newUrls.push(url)
+      newMetadata.push(metadataFor(index))
+    })
+
+    if (newUrls.length === 0) return false
+    this._urls = [...this._urls, ...newUrls]
+    this._metadata = [...this._metadata, ...newMetadata]
+    return true
+  }
+}

--- a/src/lib/playback-url-ladder.ts
+++ b/src/lib/playback-url-ladder.ts
@@ -8,9 +8,12 @@ import {
   type UrlMetadata,
   type UrlSource,
 } from './media-url-generator'
+import { filterCompatibleVariants } from './codec-compatibility'
+import type { VideoVariant } from '@/utils/video-event'
 
 export interface PlaybackUrlLadderOptions {
   urls: string[]
+  variants?: VideoVariant[]
   blossomServers: BlossomServer[]
   cachingServers?: CachingServer[]
   sha256?: string
@@ -33,11 +36,13 @@ export class PlaybackUrlLadder {
   private _urls: string[]
   private _metadata: UrlMetadata[]
   private _index = 0
+  private _error: Error | null = null
   private readonly failed = new Set<string>()
+  private readonly listeners = new Set<() => void>()
 
   constructor(options: PlaybackUrlLadderOptions) {
     this.options = options
-    const generated = this.generate(options.urls, options.sha256)
+    const generated = this.generate(this.sourceUrls(options), options.sha256)
     this._urls = generated.urls
     this._metadata = generated.metadata
   }
@@ -62,6 +67,10 @@ export class PlaybackUrlLadder {
     return this.findNextIndex(this._index + 1) !== -1
   }
 
+  get error(): Error | null {
+    return this._error
+  }
+
   get failedUrls(): string[] {
     return [...this.failed]
   }
@@ -70,47 +79,47 @@ export class PlaybackUrlLadder {
     return this.failed.has(url)
   }
 
-  /** Report the active candidate as failed and advance to the next unfailed candidate. */
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
   tryNext(): boolean {
     const current = this.currentUrl
     if (current) this.failed.add(current)
     return this.advance()
   }
 
-  /**
-   * Record a failed candidate from the player or HLS loader. A failure advances
-   * only when it belongs to the active URL; segment failures remain available
-   * to the requesting loader through {@link candidatesFor}.
-   */
   onError(url = this.currentUrl ?? undefined, _kind?: PlaybackErrorKind): boolean {
     if (!url) return false
     const isCurrent = url === this.currentUrl
     this.failed.add(url)
-    return isCurrent ? this.advance() : false
+    const advanced = isCurrent ? this.advance() : false
+    this.notify()
+    return advanced
   }
 
-  /** Start again at the first candidate that has not already failed. */
   reset(): void {
     const first = this.findNextIndex(0)
     this._index = first === -1 ? this._urls.length : first
+    this._error = null
+    this.notify()
   }
 
-  /**
-   * Re-apply the shared generation policy when the configuration changes. New
-   * candidates append without disrupting the active candidate or failed set.
-   */
   refresh(options: PlaybackUrlLadderOptions): boolean {
     this.options = options
-    const generated = this.generate(options.urls, options.sha256)
-    return this.appendNew(generated.urls, index => generated.metadata[index])
+    const generated = this.generate(this.sourceUrls(options), options.sha256)
+    const changed = this.appendNew(generated.urls, index => generated.metadata[index])
+    if (changed) this.notify()
+    return changed
   }
 
-  /** Merge asynchronous discovery candidates after the generated candidates. */
   merge(urls: string[], source: UrlSource = 'discovered'): boolean {
-    return this.appendNew(urls, () => ({ source }))
+    const changed = this.appendNew(urls, () => ({ source }))
+    if (changed) this.notify()
+    return changed
   }
 
-  /** Promote known-good candidates while preserving the current URL. */
   promote(urls: string[]): void {
     const current = this.currentUrl
     const promoted = new Set(urls.filter(url => this._urls.includes(url) && !this.failed.has(url)))
@@ -123,37 +132,47 @@ export class PlaybackUrlLadder {
     this._urls = orderedIndexes.map(index => this._urls[index])
     this._metadata = orderedIndexes.map(index => this._metadata[index])
     this._index = current ? this._urls.indexOf(current) : this.findNextIndex(0)
+    this.notify()
   }
 
-  /**
-   * Generate fallback candidates for a manifest or segment through the same
-   * policy and remove candidates already known to have failed.
-   */
   candidatesFor(url: string): string[] {
     const { sha256 } = extractBlossomHash(url)
     const candidates = sha256 ? this.generate([url], sha256).urls : [url]
     return candidates.filter(candidate => !this.failed.has(candidate))
   }
 
+  private sourceUrls(options: PlaybackUrlLadderOptions): string[] {
+    if (!options.variants) return options.urls
+    return filterCompatibleVariants(options.variants).map(variant => variant.url)
+  }
+
   private generate(urls: string[], sha256?: string): GeneratedUrls {
     if (urls.length === 0) return { urls: [], metadata: [] }
 
-    return generateMediaUrls({
-      urls,
-      blossomServers: this.options.blossomServers,
-      cachingServers: this.options.cachingServers,
-      sha256,
-      kind: this.options.kind,
-      mediaType: this.options.mediaType,
-      authorPubkey: this.options.authorPubkey,
-      proxyConfig: this.options.proxyConfig,
-    })
+    try {
+      const generated = generateMediaUrls({
+        urls,
+        blossomServers: this.options.blossomServers,
+        cachingServers: this.options.cachingServers,
+        sha256,
+        kind: this.options.kind,
+        mediaType: this.options.mediaType,
+        authorPubkey: this.options.authorPubkey,
+        proxyConfig: this.options.proxyConfig,
+      })
+      this._error = null
+      return generated
+    } catch (error) {
+      this._error = error instanceof Error ? error : new Error('Media URL generation failed')
+      return { urls: [], metadata: [] }
+    }
   }
 
   private advance(): boolean {
     const next = this.findNextIndex(this._index + 1)
     if (next === -1) return false
     this._index = next
+    this.notify()
     return true
   }
 
@@ -180,5 +199,9 @@ export class PlaybackUrlLadder {
     this._urls = [...this._urls, ...newUrls]
     this._metadata = [...this._metadata, ...newMetadata]
     return true
+  }
+
+  private notify(): void {
+    this.listeners.forEach(listener => listener())
   }
 }

--- a/src/pages/shorts/ShortsVideoPage.tsx
+++ b/src/pages/shorts/ShortsVideoPage.tsx
@@ -316,10 +316,6 @@ export function ShortsVideoPage() {
   const currentVideo = allVideos[currentVideoIndex]
   const isLoadingInitialEvent = !initialVideo && initialVideoEvent === undefined
 
-  const handleVideoUrlError = useCallback((error: Error) => {
-    console.error('Video URL failover error:', error)
-  }, [])
-
   // Memoize proxyConfig to prevent infinite loops
   const proxyConfig = useMemo(
     () => ({
@@ -328,11 +324,7 @@ export function ShortsVideoPage() {
     []
   )
 
-  const {
-    currentUrl: videoUrl,
-    moveToNext: moveToNextVideo,
-    hasMore: hasMoreVideoUrls,
-  } = useMediaUrls({
+  const { ladder: videoUrlLadder } = useMediaUrls({
     urls: currentVideo?.urls ?? [],
     mediaType: 'video',
     sha256: currentVideo?.x,
@@ -340,8 +332,10 @@ export function ShortsVideoPage() {
     authorPubkey: currentVideo?.pubkey,
     proxyConfig,
     enabled: !!currentVideo,
-    onError: handleVideoUrlError,
   })
+  const videoUrl = videoUrlLadder.currentUrl
+  const hasMoreVideoUrls = videoUrlLadder.hasMore
+  const moveToNextVideo = videoUrlLadder.tryNext.bind(videoUrlLadder)
 
   // Prefetch neighbor videos into the content-addressed Blob cache so the
   // singleton can play them instantly on swipe. Forward is the dominant swipe


### PR DESCRIPTION
Closes #38

Implemented by the local Sandcastle refactor runner.

The PR remains a draft for human review and is never auto-merged.