### PR TITLE
fix: tighten horizontal gap between shorts on mobile grids

### DIFF
--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -130,8 +130,8 @@ export const VideoCard = React.memo(function VideoCard({
   return (
     <div
       className={cn(
-        'pt-2 pb-4 hover:bg-accent rounded-lg transition-all duration-300 group hover:shadow-md hover:scale-[1.02]',
-        tightGridGap ? 'px-[0.5px] sm:px-2' : 'px-2'
+        'hover:bg-accent rounded-lg transition-all duration-300 group hover:shadow-md hover:scale-[1.02]',
+        tightGridGap ? 'px-[0.5px] py-[0.5px] sm:px-2 sm:pt-2 sm:pb-4' : 'px-2 pt-2 pb-4'
       )}
       style={{ contain: 'layout style paint' }}
     >
@@ -204,7 +204,7 @@ export const VideoCard = React.memo(function VideoCard({
             )}
           </div>
         </Link>
-        <div className="pt-3">
+        <div className={cn('pt-3', format === 'vertical' && 'hidden sm:block')}>
           <div className="flex gap-3">
             {!hideAuthor && format !== 'vertical' && (
               <Link to={authorProfileUrl} className="shrink-0">
@@ -264,9 +264,9 @@ export const VideoCardSkeleton = React.memo(function VideoCardSkeleton({
   const aspectRatio =
     format == 'vertical' ? 'aspect-[2/3]' : format == 'square' ? 'aspect-[1/1]' : 'aspect-video'
   return (
-    <div className={cn('py-2', tightGridGap ? 'px-[0.5px] sm:px-2' : 'px-2')}>
+    <div className={cn(tightGridGap ? 'px-[0.5px] py-[0.5px] sm:px-2 sm:py-2' : 'px-2 py-2')}>
       <Skeleton className={cn('w-full', aspectRatio)} />
-      <div className="pt-3">
+      <div className={cn('pt-3', format === 'vertical' && 'hidden sm:block')}>
         <div className="flex gap-3">
           {format !== 'vertical' && (
             <div className="shrink-0">

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -28,6 +28,7 @@ interface VideoCardProps {
   playlistParam?: string
   allVideos?: VideoEvent[] // Full list of videos for shorts navigation
   videoIndex?: number // Index of this video in the allVideos array
+  tightGridGap?: boolean // Minimal horizontal gap on mobile (shorts grids)
 }
 
 export const VideoCard = React.memo(function VideoCard({
@@ -37,6 +38,7 @@ export const VideoCard = React.memo(function VideoCard({
   playlistParam,
   allVideos,
   videoIndex,
+  tightGridGap,
 }: VideoCardProps) {
   const { t, i18n } = useTranslation()
   const metadata = useProfile({ pubkey: video.pubkey })
@@ -127,7 +129,10 @@ export const VideoCard = React.memo(function VideoCard({
 
   return (
     <div
-      className="p-2 pb-4 hover:bg-accent rounded-lg transition-all duration-300 group hover:shadow-md hover:scale-[1.02]"
+      className={cn(
+        'pt-2 pb-4 hover:bg-accent rounded-lg transition-all duration-300 group hover:shadow-md hover:scale-[1.02]',
+        tightGridGap ? 'px-[0.5px] sm:px-2' : 'px-2'
+      )}
       style={{ contain: 'layout style paint' }}
     >
       <div>
@@ -249,15 +254,17 @@ export const VideoCard = React.memo(function VideoCard({
 
 interface VideoCardSkeletonProps {
   format: 'vertical' | 'horizontal' | 'square'
+  tightGridGap?: boolean
 }
 
 export const VideoCardSkeleton = React.memo(function VideoCardSkeleton({
   format,
+  tightGridGap,
 }: VideoCardSkeletonProps) {
   const aspectRatio =
     format == 'vertical' ? 'aspect-[2/3]' : format == 'square' ? 'aspect-[1/1]' : 'aspect-video'
   return (
-    <div className="p-2">
+    <div className={cn('py-2', tightGridGap ? 'px-[0.5px] sm:px-2' : 'px-2')}>
       <Skeleton className={cn('w-full', aspectRatio)} />
       <div className="pt-3">
         <div className="flex gap-3">

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -170,7 +170,7 @@ export const VideoCard = React.memo(function VideoCard({
                       className="absolute inset-0 w-full h-full object-cover"
                     />
                   ) : (
-                    <Skeleton className="absolute inset-0 w-full h-full" />
+                    <Skeleton className="absolute inset-0 w-full h-full rounded-none sm:rounded-lg" />
                   ))}
                 <img
                   src={cascade.src ?? ''}
@@ -265,7 +265,7 @@ export const VideoCardSkeleton = React.memo(function VideoCardSkeleton({
     format == 'vertical' ? 'aspect-[2/3]' : format == 'square' ? 'aspect-[1/1]' : 'aspect-video'
   return (
     <div className={cn(tightGridGap ? 'px-[0.5px] py-[0.5px] sm:px-2 sm:py-2' : 'px-2 py-2')}>
-      <Skeleton className={cn('w-full', aspectRatio)} />
+      <Skeleton className={cn('w-full rounded-none sm:rounded-lg', aspectRatio)} />
       <div className={cn('pt-3', format === 'vertical' && 'hidden sm:block')}>
         <div className="flex gap-3">
           {format !== 'vertical' && (

--- a/src/components/VideoCard.tsx
+++ b/src/components/VideoCard.tsx
@@ -130,8 +130,10 @@ export const VideoCard = React.memo(function VideoCard({
   return (
     <div
       className={cn(
-        'hover:bg-accent rounded-lg transition-all duration-300 group hover:shadow-md hover:scale-[1.02]',
-        tightGridGap ? 'px-[0.5px] py-[0.5px] sm:px-2 sm:pt-2 sm:pb-4' : 'px-2 pt-2 pb-4'
+        'hover:bg-accent transition-all duration-300 group hover:shadow-md hover:scale-[1.02]',
+        tightGridGap
+          ? 'rounded-none sm:rounded-lg px-[0.5px] py-[0.5px] sm:px-2 sm:pt-2 sm:pb-4'
+          : 'rounded-lg px-2 pt-2 pb-4'
       )}
       style={{ contain: 'layout style paint' }}
     >
@@ -139,7 +141,10 @@ export const VideoCard = React.memo(function VideoCard({
         <Link to={to} onClick={handleShortsClick}>
           {/* Container with fixed aspect ratio ensures consistent size regardless of thumbnail state */}
           <div
-            className={cn('w-full overflow-hidden sm:rounded-lg relative bg-muted', aspectRatio)}
+            className={cn(
+              'w-full overflow-hidden rounded-none sm:rounded-lg relative bg-muted',
+              aspectRatio
+            )}
           >
             {/* Show error state if both thumbnail and fallback failed */}
             {cascade.exhausted ? (

--- a/src/components/VideoGrid.tsx
+++ b/src/components/VideoGrid.tsx
@@ -117,7 +117,7 @@ export function VideoGrid({
           {chunk(Array.from({ length: 24 }), portraitCols).map((row, i) => (
             <div key={'portrait-skel-' + i} className={`grid ${gridColsClass(portraitCols)}`}>
               {row.map((_, j) => (
-                <VideoCardSkeleton key={j} format="vertical" />
+                <VideoCardSkeleton key={j} format="vertical" tightGridGap />
               ))}
             </div>
           ))}
@@ -140,7 +140,7 @@ export function VideoGrid({
         )}
       >
         {Array.from({ length: 24 }).map((_, i) => (
-          <VideoCardSkeleton key={i} format={cardFormat} />
+          <VideoCardSkeleton key={i} format={cardFormat} tightGridGap={isShort} />
         ))}
       </div>
     )
@@ -198,6 +198,7 @@ export function VideoGrid({
                 playlistParam={playlistParam}
                 allVideos={portraitVideos}
                 videoIndex={portraitIndexMap.get(video.id)}
+                tightGridGap
               />
             ))}
           </div>
@@ -233,6 +234,7 @@ export function VideoGrid({
           playlistParam={playlistParam}
           allVideos={isShort ? filteredVideos : undefined}
           videoIndex={isShort ? index : undefined}
+          tightGridGap={isShort}
         />
       ))}
     </div>

--- a/src/components/page-loaders.tsx
+++ b/src/components/page-loaders.tsx
@@ -49,7 +49,7 @@ export function ShortsFeedPageLoader() {
       <div className="sm:p-2">
         <div className={VERTICAL_GRID}>
           {Array.from({ length: 24 }).map((_, i) => (
-            <VideoCardSkeleton key={i} format="vertical" />
+            <VideoCardSkeleton key={i} format="vertical" tightGridGap />
           ))}
         </div>
       </div>

--- a/src/pages/AuthorPage.tsx
+++ b/src/pages/AuthorPage.tsx
@@ -1196,7 +1196,7 @@ export function AuthorPage() {
                   </Button>
                 </div>
                 <div className="w-full overflow-x-auto scrollbar-hide">
-                  <div className="flex gap-2 min-w-max">
+                  <div className="flex gap-0 sm:gap-2 min-w-max">
                     {shorts.slice(0, 10).map((video, index) => (
                       <div key={`latest-short-${video.id}`} className="w-44 shrink-0">
                         <VideoCard
@@ -1204,6 +1204,7 @@ export function AuthorPage() {
                           format="vertical"
                           allVideos={shorts}
                           videoIndex={index}
+                          tightGridGap
                         />
                       </div>
                     ))}


### PR DESCRIPTION
VideoCard's own padding created the visual gap between grid items.
Shorts (vertical format) now use near-zero horizontal padding below
the sm breakpoint, shrinking the x-gap to ~1px while leaving the
vertical gap between rows untouched. Applies everywhere shorts render
in a grid (VideoGrid auto/vertical modes and their loading skeletons),
covering the /shorts feed, profile shorts tab, and mixed grids.