### PR TITLE
fix: stop looping the outgoing short on slow networks, add buffering spinner, prebuffer neighbors

### DIFF
--- a/src/hooks/useVideoPrefetch.ts
+++ b/src/hooks/useVideoPrefetch.ts
@@ -3,10 +3,13 @@
  *
  * Resolves a video's playback URL through the same pipeline the active player
  * uses (generateMediaUrls + kind 1063 discovery, cached by sha256), then GETs
- * the resolved URL to warm the browser's HTTP cache. When that video later
- * becomes active, the <video> element's byte request is served locally instead
- * of hitting the network — removing the fetch + demux latency from the
- * swipe-to-playback critical path.
+ * the resolved URL and keeps the downloaded bytes as a Blob in a small
+ * module-level cache. When that video later becomes active, the shorts
+ * singleton can play the cached Blob directly via an object URL — a real,
+ * guaranteed-instant local source rather than hoping the browser's HTTP cache
+ * will serve the <video> element's range requests. This removes the buffering
+ * gap from the swipe-to-playback critical path, which HTTP-cache warming
+ * alone doesn't reliably do (range requests aren't always served from cache).
  *
  * Best-effort: errors are swallowed. The active player's own failover still
  * handles real playback failures. Prefetch is skipped on Data Saver / 2g to
@@ -15,6 +18,27 @@
 import { useEffect, useRef } from 'react'
 import { useMediaUrls } from './useMediaUrls'
 import type { VideoEvent } from '@/utils/video-event'
+
+// Bounded to roughly the number of neighbors the shorts deck prefetches
+// (next + previous) plus a little slack for fast successive swipes.
+const MAX_CACHED_BLOBS = 3
+const prefetchedBlobs = new Map<string, Blob>()
+
+/** Returns the fully-downloaded Blob for a video URL, if it was prefetched. */
+export function getPrefetchedVideoBlob(url: string): Blob | undefined {
+  return prefetchedBlobs.get(url)
+}
+
+function cachePrefetchedBlob(url: string, blob: Blob): void {
+  // Re-inserting refreshes recency (Map preserves insertion order).
+  prefetchedBlobs.delete(url)
+  prefetchedBlobs.set(url, blob)
+  while (prefetchedBlobs.size > MAX_CACHED_BLOBS) {
+    const oldestKey = prefetchedBlobs.keys().next().value
+    if (oldestKey === undefined) break
+    prefetchedBlobs.delete(oldestKey)
+  }
+}
 
 interface UseVideoPrefetchOptions {
   video: VideoEvent | null
@@ -81,9 +105,10 @@ export function useVideoPrefetch({ video, enabled }: UseVideoPrefetchOptions): v
     })
       .then(response => {
         if (!response.ok) return undefined
-        // Drain to completion so the full response is cached. A Blob is backed
-        // by a file reference (not JS heap) and is discarded immediately.
         return response.blob()
+      })
+      .then(blob => {
+        if (blob) cachePrefetchedBlob(currentUrl, blob)
       })
       .catch(error => {
         if (error instanceof DOMException && error.name === 'AbortError') return

--- a/src/pages/shorts/ShortsVideoPage.tsx
+++ b/src/pages/shorts/ShortsVideoPage.tsx
@@ -32,8 +32,9 @@ import {
 import { getKindsForType } from '@/lib/video-types'
 import { Header } from '@/components/Header'
 import { PlayPauseOverlay } from '@/components/PlayPauseOverlay'
+import { LoadingSpinner } from '@/components/player'
 import { useMediaUrls } from '@/hooks/useMediaUrls'
-import { useVideoPrefetch } from '@/hooks/useVideoPrefetch'
+import { useVideoPrefetch, getPrefetchedVideoBlob } from '@/hooks/useVideoPrefetch'
 import { useShortsFeedStore } from '@/stores/shortsFeedStore'
 import { ShortVideoItem } from './ShortVideoItem'
 import { ShortVideoOverlay } from './ShortVideoOverlay'
@@ -81,6 +82,7 @@ export function ShortsVideoPage() {
   const userPausedRef = useRef(false)
   const initializedVideoElementRef = useRef(false)
   const sourceSwitchIdRef = useRef(0)
+  const objectUrlRef = useRef<string | null>(null)
   const dragStateRef = useRef<DragState | null>(null)
   const wheelCooldownTimeoutRef = useRef<number | undefined>(undefined)
   const [deckOffsetY, setDeckOffsetY] = useState(0)
@@ -88,6 +90,8 @@ export function ShortsVideoPage() {
   const [settlingTargetIndex, setSettlingTargetIndex] = useState<number | null>(null)
   const [naturalAspectRatio, setNaturalAspectRatio] = useState<number | null>(null)
   const [isVideoReady, setIsVideoReady] = useState(false)
+  const [isBuffering, setIsBuffering] = useState(false)
+  const [showBufferingSpinner, setShowBufferingSpinner] = useState(false)
 
   // Use centralized read relays hook
   const readRelays = useReadRelays()
@@ -401,6 +405,16 @@ export function ShortsVideoPage() {
     initializedVideoElementRef.current = true
   }, [])
 
+  // Revoke any outstanding prefetch object URL when the component unmounts.
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current)
+        objectUrlRef.current = null
+      }
+    }
+  }, [])
+
   useEffect(() => {
     const videoElement = singletonVideoRef.current
     if (!videoElement || !currentVideo || !videoUrl) return
@@ -420,8 +434,12 @@ export function ShortsVideoPage() {
       }
     }
 
+    // Compare against the canonical remote URL we recorded for this element,
+    // not videoElement.src directly — the assigned src may be a local object
+    // URL (from a prefetched Blob) rather than videoUrl itself.
     const sourceChanged =
-      videoElement.dataset.videoId !== currentVideo.id || videoElement.src !== videoUrl
+      videoElement.dataset.videoId !== currentVideo.id ||
+      videoElement.dataset.sourceUrl !== videoUrl
     if (!sourceChanged) {
       playCurrentSource()
       return
@@ -430,24 +448,51 @@ export function ShortsVideoPage() {
     const switchId = sourceSwitchIdRef.current + 1
     sourceSwitchIdRef.current = switchId
     setIsVideoReady(false)
+    setIsBuffering(true)
 
+    // Stop and hide the outgoing video immediately so a slow-loading next
+    // video never appears to keep looping the previous one.
     const mutedPreference = userMutedPreferenceRef.current ?? videoElement.muted
     videoElement.pause()
     videoElement.removeAttribute('src')
     videoElement.dataset.videoId = ''
+    videoElement.dataset.sourceUrl = ''
     videoElement.load()
 
-    window.requestAnimationFrame(() => {
+    const rafId = window.requestAnimationFrame(() => {
       if (sourceSwitchIdRef.current !== switchId) return
 
+      // Prefer a fully prefetched Blob (see useVideoPrefetch): playing it via
+      // an object URL is a real local source, so playback starts instantly
+      // with no buffering, instead of hoping the browser's HTTP cache can
+      // serve the <video> element's range requests.
+      const prefetchedBlob = getPrefetchedVideoBlob(videoUrl)
+      const previousObjectUrl = objectUrlRef.current
+      objectUrlRef.current = null
+
       videoElement.dataset.videoId = currentVideo.id
-      videoElement.src = videoUrl
+      videoElement.dataset.sourceUrl = videoUrl
+      if (prefetchedBlob) {
+        const objectUrl = URL.createObjectURL(prefetchedBlob)
+        objectUrlRef.current = objectUrl
+        videoElement.src = objectUrl
+      } else {
+        videoElement.src = videoUrl
+      }
       videoElement.currentTime = 0
       videoElement.muted = mutedPreference
       videoElement.load()
       userPausedRef.current = false
       playCurrentSource()
+
+      if (previousObjectUrl) {
+        URL.revokeObjectURL(previousObjectUrl)
+      }
     })
+
+    return () => {
+      window.cancelAnimationFrame(rafId)
+    }
   }, [currentVideo, videoUrl])
 
   const handleVideoError = useCallback(() => {
@@ -474,6 +519,7 @@ export function ShortsVideoPage() {
       if (sourceSwitchIdRef.current !== switchId) return
       if (videoElement.dataset.videoId !== currentVideo.id) return
       setIsVideoReady(true)
+      setIsBuffering(false)
     }
 
     if (typeof videoElement.requestVideoFrameCallback === 'function') {
@@ -488,6 +534,23 @@ export function ShortsVideoPage() {
       })
     }
   }, [currentVideo])
+
+  // Mid-playback rebuffering (e.g. the current video stalls on a slow
+  // connection): show the same loading feedback as an initial swap.
+  const handleVideoWaiting = useCallback(() => {
+    setIsBuffering(true)
+  }, [])
+
+  // Debounce the spinner so brief/instant loads never flash it.
+  useEffect(() => {
+    if (!isBuffering) {
+      setShowBufferingSpinner(false)
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => setShowBufferingSpinner(true), 500)
+    return () => window.clearTimeout(timeoutId)
+  }, [isBuffering])
 
   const handleVideoClick = useCallback(() => {
     const videoElement = singletonVideoRef.current
@@ -807,7 +870,9 @@ export function ShortsVideoPage() {
                   onLoadedData={handleVideoLoadedData}
                   onCanPlay={handleVideoLoadedData}
                   onPlaying={handleVideoLoadedData}
+                  onWaiting={handleVideoWaiting}
                 />
+                <LoadingSpinner isVisible={showBufferingSpinner} />
                 <PlayPauseOverlay
                   videoRef={singletonVideoRef}
                   userInitiatedRef={userInitiatedPlayPauseRef}


### PR DESCRIPTION
On slow connections the singleton video could keep showing/looping the
previous short while the next one was still resolving, since the
source-change check compared videoElement.src (which may already have
been reassigned mid-swap) instead of a stable marker. Track the
canonical remote URL in a dataset attribute and cancel any in-flight
swap (via its scheduled rAF) when a newer swipe supersedes it, so an
outgoing video is always paused and hidden before the next one loads.

Add a debounced buffering spinner (matching the main VideoPlayer's
LoadingSpinner) so slow loads are visibly communicated instead of
showing nothing.

useVideoPrefetch now retains the downloaded neighbor bytes as a Blob
(capped small cache) instead of discarding them after warming the HTTP
cache. On swipe, the singleton plays the prefetched Blob via an object
URL when available — a guaranteed-local source instead of hoping the
browser's HTTP cache serves the <video> element's range requests — so
swiping to an already-prefetched neighbor starts instantly with no
buffering. The singleton <video> element itself is still reused across
swipes (unchanged), preserving iOS audio playback.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014tLW3fTYXu27XQ4RQyLVpi