### PR TITLE
Make QR login signer button primary on iOS, matching Android

### DIFF
--- a/src/components/auth/QRCodeLogin.tsx
+++ b/src/components/auth/QRCodeLogin.tsx
@@ -8,16 +8,10 @@ import { Button } from '@/components/ui/button'
 import { saveAccountToStorage, saveActiveAccount } from '@/hooks/useAccountPersistence'
 import { presetRelays } from '@/constants/relays'
 import { subscriptionMethod, publishMethod } from '@/nostr/core'
-import { isIOSDevice } from '@/lib/codec-compatibility'
 import { useTranslation } from 'react-i18next'
 
 // Relays used for nostrconnect communication
 const NOSTRCONNECT_RELAYS = presetRelays.map(r => r.url)
-
-function isAndroidDevice(): boolean {
-  if (typeof navigator === 'undefined') return false
-  return /Android/i.test(navigator.userAgent)
-}
 
 // Build a bunker:// URI from signer properties for persistence
 function buildBunkerUri(remotePubkey: string, relays: string[], secret?: string): string {
@@ -41,12 +35,6 @@ export function QRCodeLogin({ onLogin, onError }: QRCodeLoginProps) {
   const [copied, setCopied] = useState(false)
   const signerRef = useRef<NostrConnectSigner | null>(null)
   const abortControllerRef = useRef<AbortController | null>(null)
-  const isAndroid = isAndroidDevice()
-  const isIOS = isIOSDevice()
-  const openButtonVariant = isAndroid ? 'default' : 'ghost'
-  const copyButtonVariant = isIOS ? 'default' : 'ghost'
-  const openButtonClassName = isAndroid ? undefined : 'text-muted-foreground'
-  const copyButtonClassName = isIOS ? undefined : 'text-muted-foreground'
 
   if (!accountManager) {
     throw new Error('QRCodeLogin must be used within AccountsProvider')
@@ -174,24 +162,24 @@ export function QRCodeLogin({ onLogin, onError }: QRCodeLoginProps) {
 
       <div className="flex flex-wrap items-center justify-center gap-2">
         {nostrConnectUri ? (
-          <Button asChild variant={openButtonVariant} size="sm" className={openButtonClassName}>
+          <Button asChild variant="default" size="sm">
             <a href={nostrConnectUri}>
               <ExternalLink className="w-4 h-4 mr-2" />
               {t('auth.login.qrOpen', 'Use Signer')}
             </a>
           </Button>
         ) : (
-          <Button variant={openButtonVariant} size="sm" disabled className={openButtonClassName}>
+          <Button variant="default" size="sm" disabled>
             <ExternalLink className="w-4 h-4 mr-2" />
             {t('auth.login.qrOpen', 'Use Signer')}
           </Button>
         )}
         <Button
-          variant={copyButtonVariant}
+          variant="ghost"
           size="sm"
           onClick={handleCopy}
           disabled={!nostrConnectUri}
-          className={copyButtonClassName}
+          className="text-muted-foreground"
           aria-label={copied ? t('common.copied', 'Copied!') : t('common.copy', 'Copy')}
           title={copied ? t('common.copied', 'Copied!') : t('common.copy', 'Copy')}
         >


### PR DESCRIPTION
The "Use Signer" button was styled as ghost on iOS (with Copy as
primary instead), while Android always had the signer button as
primary. Align iOS with Android: signer button primary, copy button
secondary on both platforms.